### PR TITLE
[feat/fe-nav] Nav 컴포넌트 뷰 작업

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -53,6 +53,7 @@
 
 body {
 	margin: 0;
+	background: var(--background-color);
 	font-family: "Noto Sans KR", sans-serif;
 	font-weight: var(--fw-normal);
 	font-size: var(--fs-normal);
@@ -64,7 +65,7 @@ body {
 	align-items: center;
 	width: 100%;
 	min-height: 72px;
-	padding: 16px;
+	padding: 0 16px;
 	box-sizing: border-box;
 	background: var(--primary-color);
 }
@@ -109,6 +110,71 @@ body {
 }
 .button_logout {
 	background-color: var(--primary-container-color);
+}
+
+/* nav */
+.nav {
+	width: 300px;
+	padding: 16px 0;
+	background: var(--white);
+	box-shadow: var(--bs-layer1);
+}
+.nav_menu {
+	padding: 0 16px;
+}
+.nav a {
+	display: flex;
+	align-items: center;
+	height: 56px;
+	padding: 0 16px;
+	border-radius: var(--br-md);
+	color: var(--on-background-color);
+}
+.nav a:hover {
+	background: var(--primary-container-color);
+	color: var(--primary-color);
+}
+.nav a:focus {
+	background: var(--primary-container-color);
+	color: var(--primary-color);
+}
+.nav .home_link {
+	padding: 0 16px;
+}
+.nav .home_link svg {
+	margin-right: 12px;
+}
+.nav .home_link a:hover svg path,
+.nav .home_link a:focus svg path {
+	fill: var(--primary-color);
+}
+.nav a .toggle_updown {
+	width: 24px;
+	height: 24px;
+	margin-left: auto;
+}
+.depth2 {
+	padding: 12px 0;
+}
+.depth2 .nav_menu_item a {
+	position: relative;
+	height: 36px;
+	padding: 0 16px 0 36px;
+	font-size: var(--fs-caption);
+}
+.depth2 .nav_menu_item a:hover {
+	background: none;
+	color: var(--primary-color);
+}
+.depth2 .nav_menu_item a:hover::before {
+	content: "";
+	position: absolute;
+	left: 16px;
+	display: block;
+	width: 8px;
+	height: 8px;
+	border-radius: 100%;
+	background: var(--primary-color);
 }
 
 /* button */

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,11 +3,13 @@ import "./App.css";
 import Button from "./components/Button";
 import Input from "./components/Input";
 import Header from "./components/Header";
+import Nav from "./components/Nav";
 
 function App() {
 	return (
 		<div className="App">
 			<Header isLogin={false} />
+			<Nav />
 			<section>
 				<Button buttonType="no_em" buttonSize="big" buttonLabel="테스트" />
 				<Input

--- a/client/src/assets/icon _menu_.svg
+++ b/client/src/assets/icon _menu_.svg
@@ -1,3 +1,0 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M3 18H21V16H3V18ZM3 13H21V11H3V13ZM3 6V8H21V6H3Z" fill="white"/>
-</svg>

--- a/client/src/assets/icon_arrow_down.svg
+++ b/client/src/assets/icon_arrow_down.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.59 15.41L12 10.83L7.41 15.41L6 14L12 8.00003L18 14L16.59 15.41Z" fill="#454151"/>
+</svg>

--- a/client/src/assets/icon_home.svg
+++ b/client/src/assets/icon_home.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 5.69L17 10.19V18H15V12H9V18H7V10.19L12 5.69ZM12 3L2 12H5V20H11V14H13V20H19V12H22L12 3Z" fill="#454151"/>
+</svg>

--- a/client/src/assets/icon_menu.svg
+++ b/client/src/assets/icon_menu.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 18H21V16H3V18ZM3 13H21V11H3V13ZM3 6V8H21V6H3Z" fill="white"/>
+</svg>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,6 +1,6 @@
 // import { ReactComponent as iconMenu } from "./../assets/icon _menu_.svg";
 import { useState } from "react";
-import iconMenu from "./../assets/icon _menu_.svg";
+import iconMenu from "./../assets/icon_menu.svg";
 import iconWrite from "./../assets/edit_document.svg";
 import iconLogout from "./../assets/logout.svg";
 

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -1,0 +1,38 @@
+import boardData from "./../data/boardData.json";
+import { ReactComponent as IconHome } from "./../assets/icon_home.svg";
+import iconArrowDown from "./../assets/icon_arrow_down.svg";
+
+const createMenuNode = (data: any[]) => {
+	return data.map((el: any, idx: number) => (
+		<li key={idx} className="nav_menu_item">
+			{el.name ? (
+				<a href="./">
+					{el.name}
+					<button className="toggle_updown up">
+						<img src={iconArrowDown} alt="메뉴 펼치기 접기 토글 아이콘" />
+					</button>
+				</a>
+			) : (
+				<a href="./">{el.categoryName}</a>
+			)}
+			{el.categories && el.categories.length !== 0 ? (
+				<ul className="nav_menu depth2">{createMenuNode(el.categories)}</ul>
+			) : null}
+		</li>
+	));
+};
+
+const Nav = () => {
+	return (
+		<nav className="nav">
+			<div className="home_link">
+				<a href="./">
+					<IconHome />
+					HOME
+				</a>
+			</div>
+			<ul className="nav_menu depth1">{createMenuNode(boardData)}</ul>
+		</nav>
+	);
+};
+export default Nav;

--- a/client/src/data/boardData.json
+++ b/client/src/data/boardData.json
@@ -1,0 +1,148 @@
+[
+	{
+		"id": 1,
+		"name": "첫번째 게시판",
+		"orderIndex": 1,
+		"categories": [
+			{
+				"id": 1,
+				"categoryName": "카테고리a",
+				"orderIndex": 1,
+				"adminOnly": false
+			},
+			{
+				"id": 2,
+				"categoryName": "카테고리b",
+				"orderIndex": 2,
+				"adminOnly": false
+			},
+			{
+				"id": 5,
+				"categoryName": "카테고리0",
+				"orderIndex": 3,
+				"adminOnly": false
+			},
+			{
+				"id": 6,
+				"categoryName": "카테고리1",
+				"orderIndex": 4,
+				"adminOnly": false
+			},
+			{
+				"id": 7,
+				"categoryName": "카테고리2",
+				"orderIndex": 5,
+				"adminOnly": false
+			},
+			{
+				"id": 8,
+				"categoryName": "카테고리3",
+				"orderIndex": 6,
+				"adminOnly": false
+			},
+			{
+				"id": 9,
+				"categoryName": "카테고리4",
+				"orderIndex": 7,
+				"adminOnly": false
+			},
+			{
+				"id": 10,
+				"categoryName": "카테고리5",
+				"orderIndex": 8,
+				"adminOnly": false
+			},
+			{
+				"id": 11,
+				"categoryName": "카테고리6",
+				"orderIndex": 9,
+				"adminOnly": false
+			},
+			{
+				"id": 12,
+				"categoryName": "카테고리7",
+				"orderIndex": 10,
+				"adminOnly": false
+			},
+			{
+				"id": 13,
+				"categoryName": "카테고리8",
+				"orderIndex": 11,
+				"adminOnly": false
+			},
+			{
+				"id": 14,
+				"categoryName": "카테고리9",
+				"orderIndex": 12,
+				"adminOnly": false
+			}
+		]
+	},
+	{
+		"id": 2,
+		"name": "두번째 게시판",
+		"orderIndex": 2,
+		"categories": [
+			{
+				"id": 3,
+				"categoryName": "카테고리c",
+				"orderIndex": 3,
+				"adminOnly": false
+			},
+			{
+				"id": 4,
+				"categoryName": "카테고리d",
+				"orderIndex": 3,
+				"adminOnly": false
+			}
+		]
+	},
+	{
+		"id": 3,
+		"name": "3번째 게시판",
+		"orderIndex": 3,
+		"categories": []
+	},
+	{
+		"id": 4,
+		"name": "4번째 게시판",
+		"orderIndex": 4,
+		"categories": []
+	},
+	{
+		"id": 5,
+		"name": "5번째 게시판",
+		"orderIndex": 5,
+		"categories": []
+	},
+	{
+		"id": 6,
+		"name": "6번째 게시판",
+		"orderIndex": 6,
+		"categories": []
+	},
+	{
+		"id": 7,
+		"name": "7번째 게시판",
+		"orderIndex": 7,
+		"categories": []
+	},
+	{
+		"id": 8,
+		"name": "8번째 게시판",
+		"orderIndex": 8,
+		"categories": []
+	},
+	{
+		"id": 9,
+		"name": "9번째 게시판",
+		"orderIndex": 9,
+		"categories": []
+	},
+	{
+		"id": 10,
+		"name": "10번째 게시판",
+		"orderIndex": 10,
+		"categories": []
+	}
+]


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [X]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
Nav컴포넌트 추가 및 뷰 작업
- Nav 컴포넌트 파일 생성
  - 메뉴가 2depth로 구성이 되어 있어 재귀를 사용해 메뉴를 불러오도록 함수를 제작했습니다.
  - 실제 api의 데이터를 받아오면 달라질 수 있어서 확실하지 않은 타입은 부득이하게 `any`, `any[]`를 사용했습니다.
  - 하단 메뉴를 접고 펼치는 토글 기능은 후에 작업할 예정입니다.
- Nav 컴포넌트 CSS 추가
- 필요한 svg 파일 추가
  - 기존 svg파일 중 파일 중 잘못된 것이 있어 같이 추가하고 파일명을 변경하였습니다.
- API문서를 참고하여 메뉴 더미데이터 생성
  - 추후 api연결시 수고를 덜기 위해 api문서의 예시 데이터를 더미데이터로 만들어 사용했습니다.

# 느낀 점 및 어려운 점
## 느낀 점
- 작업시 큰 어려움은 없었지만... 코딩테스트와 취준 때문에 간만에 작업하려니 어색함을 느꼈습니다. 특히 코딩테스트 때는 자바스크립트만 쓰다가 타입스크립트로 작업하려니 적응하는 시간이 걸리긴 합니다.
- 코드 작업보다, 처음부터 만들다보니 디렉토리 구조나 아키텍처가 제일 고민하게 되는것 같습니다. 어떤 구조가 좋을지는 계속 검색해보고 벤치마킹해보는 것이 좋은 방법일 것 같습니다.
## 어려운 점
- 기존 컴퓨터가 아니라 다른 맥 노트북을 사용해 `git fetch orign`를 해도 에러는 안 뜨지만 `git branch`를 입력해보면 로컬에 뜨지 않았었습니다. 그냥 같은 이름의 브랜치를 입력해도 상관없지만, vscode 하단의 브랜치명과 터미널의 로컬 브랜치명을 일치시켜주고 싶었습니다. 그러나 여러 번 시도해도 일치가 안되어 `git remote update`를 입력했으나 해결이 안되었습니다. 뭔가 꼬여서 제대로 반영이 안 된 것 같아 로컬에서 백업 후 깃 초기화하고, 다시 리포지토리에서 기존 작업물을 내려받아 `git remote update`를 입력하니 해결이 되었습니다. 아까운 시간...
- 작업할 때 터미널을 선호하지만, 커밋 메시지를 하나하나 입력하는데는 vscode의 소스 제어 기능을 이용합니다. 이게 훨씬 편하거든요. 그런데 맥의 경우 파일 경로에 한글이 있으면 `git:fatal: ~ is outside repository at ~` 이런 경고문이 뜨면서 안됩니다... 덕분에 삽질도 하고 경로 다 바꾸고 해결했습니다. 다음은 도움이 된 참고 링크입니다.
https://gyong0117.tistory.com/entry/M1-%EB%A7%A5%EB%B6%81-Git-fatal-is-outside-repository-at-%EC%98%A4%EB%A5%98-%ED%95%B4%EA%B2%B0

# [option] 관련 알림사항
- 새로운 브랜치로 Nav 컴포넌트의 접힘 펼침 기능을 작업할 예정입니다.
