### PR TITLE
[feat/fe-navFold] 네비게이션 접힘 및 펼치기 기능 추가

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -50,14 +50,37 @@
 	/* box-shadow */
 	--bs-layer1: 8px 11px 29px 0px rgba(129, 127, 139, 0.15);
 }
-
+html {
+	height: 100%;
+}
 body {
+	height: 100%;
 	margin: 0;
-	background: var(--background-color);
 	font-family: "Noto Sans KR", sans-serif;
 	font-weight: var(--fw-normal);
 	font-size: var(--fs-normal);
 	color: var(--on-background-color);
+}
+/* layout */
+#root {
+	height: 100%;
+}
+.App {
+	display: flex;
+	flex-direction: column;
+	min-height: 100%;
+	background: var(--background-color);
+}
+.page_wrap {
+	display: flex;
+	flex: 1;
+	position: relative;
+}
+.page_wrap .container {
+	width: 100%;
+	max-width: 1100px;
+	padding: 40px;
+	margin: 0 auto;
 }
 /* header */
 .header {
@@ -114,6 +137,7 @@ body {
 
 /* nav */
 .nav {
+	flex: 0 0 auto;
 	width: 300px;
 	padding: 16px 0;
 	background: var(--white);
@@ -153,8 +177,14 @@ body {
 	height: 24px;
 	margin-left: auto;
 }
+.nav a.unfold .toggle_updown {
+	transform: rotate(180deg);
+}
 .depth2 {
-	padding: 12px 0;
+	padding: 0;
+	transition: all 0.3s;
+	max-height: 0;
+	overflow: hidden;
 }
 .depth2 .nav_menu_item a {
 	position: relative;
@@ -175,6 +205,10 @@ body {
 	height: 8px;
 	border-radius: 100%;
 	background: var(--primary-color);
+}
+.nav a.unfold + .nav_menu.depth2 {
+	max-height: fit-content;
+	padding: 12px 0;
 }
 
 /* button */

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,16 +9,20 @@ function App() {
 	return (
 		<div className="App">
 			<Header isLogin={false} />
-			<Nav />
-			<section>
-				<Button buttonType="no_em" buttonSize="big" buttonLabel="테스트" />
-				<Input
-					InputLabel="테스트"
-					isLabel={true}
-					errorMsg="이것은 오류일 때 나타납니다"
-					inputAttr={{ type: "text", placeholder: "입력하세요" }}
-				/>
-			</section>
+			<div className="page_wrap">
+				<Nav />
+				<main className="container">
+					<section>
+						<Button buttonType="no_em" buttonSize="big" buttonLabel="테스트" />
+						<Input
+							InputLabel="테스트"
+							isLabel={true}
+							errorMsg="이것은 오류일 때 나타납니다"
+							inputAttr={{ type: "text", placeholder: "입력하세요" }}
+						/>
+					</section>
+				</main>
+			</div>
 		</div>
 	);
 }

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -1,25 +1,34 @@
 import boardData from "./../data/boardData.json";
 import { ReactComponent as IconHome } from "./../assets/icon_home.svg";
 import iconArrowDown from "./../assets/icon_arrow_down.svg";
+import { MouseEvent } from "react";
 
 const createMenuNode = (data: any[]) => {
 	return data.map((el: any, idx: number) => (
 		<li key={idx} className="nav_menu_item">
 			{el.name ? (
-				<a href="./">
+				<a href="" onClick={clickHandler}>
 					{el.name}
-					<button className="toggle_updown up">
-						<img src={iconArrowDown} alt="메뉴 펼치기 접기 토글 아이콘" />
-					</button>
+					{el.categories && el.categories.length !== 0 ? (
+						<i className="toggle_updown">
+							<img src={iconArrowDown} alt="메뉴 펼치기 접기 토글 아이콘" />
+						</i>
+					) : null}
 				</a>
 			) : (
-				<a href="./">{el.categoryName}</a>
+				<a href="">{el.categoryName}</a>
 			)}
 			{el.categories && el.categories.length !== 0 ? (
 				<ul className="nav_menu depth2">{createMenuNode(el.categories)}</ul>
 			) : null}
 		</li>
 	));
+};
+
+const clickHandler = (event: React.MouseEvent<HTMLAnchorElement>): void => {
+	event.preventDefault();
+	console.log(event.currentTarget.classList);
+	event.currentTarget.classList.toggle("unfold");
 };
 
 const Nav = () => {


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 네비게이션 접힘, 펼치기 기능 추가
- CSS 추가 및 수정
- 네비게이션 위치 조정에 따른 레이아웃 스타일 조정

# 느낀 점 및 어려운 점
- 타입스크립트+리액트에서 이벤트핸들러의 이벤트 객체를 받아올 때의 타입에 대해 학습했습니다. 받아오려는 이벤트 객체는 `React.MouseEvent<HTMLAnchorElement>`로 지정해주어야 합니다. `<>`안의 내용은 이벤트핸들러를 적용할 대상입니다. 
- UX 및 웹표준 상으로 anchor태그 안에 버튼을 넣지 않아 게시판 링크 클릭시 토글 버튼과 함께 작용하도록 적용했습니다.
- 게시판 링크와 관련해 게시판-카테고리 요구사항을 정리할 필요가 있어 일단 현행유지한 상태로 기능만 추가하였습니다.

# [option] 관련 알림사항
- 참고가 되는 블로그(https://ge0nmo.tistory.com/category/AWS)를 보니 게시판에 하위 메뉴가 있는 경우 해당 게시판으로 이동이 안됩니다. 접힘 펼침 기능만 적용이 됩니다. 문제는 주소 표시줄에서 하위 메뉴를 지우면 게시판에 접근이 가능하다는 겁니다. 즉 클릭만으로는 사용자가 게시판 전체에 접근이 불가해서 이와 관련해 로직을 정리할 필요가 있겠습니다. 
일단은 현행 유지한 채로 접힘, 펼침 기능을 적용하였습니다. 
