### PR TITLE
[feat/fe-selectBox] 셀렉트 박스 컴포넌트 생성

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -344,6 +344,60 @@ input.error {
 	padding: 16px 24px;
 }
 
+/* select (custom) */
+.custom_select {
+	min-width: 250px;
+}
+.custom_select .label {
+	margin-bottom: 6px;
+}
+.custom_select .select_body {
+	position: relative;
+	width: 100%;
+	height: 48px;
+	padding: 8px 56px 8px 16px;
+	border: 1px solid var(--border-color);
+	border-radius: var(--br-md);
+	background: var(--white);
+	color: var(--on-background-secondary-color);
+	line-height: 30px;
+}
+.custom_select .select_body::after {
+	content: "";
+	position: absolute;
+	top: 11px;
+	right: 16px;
+	width: 24px;
+	height: 24px;
+	background-image: url("./assets/icon_arrow_down.svg");
+	background-repeat: no-repeat;
+	background-position: center;
+	transform: rotate(180deg);
+}
+.custom_select .option_list {
+	display: none;
+	border: 1px solid var(--border-color);
+	border-top: 0 none;
+	border-radius: 0 0 8px 8px;
+	background: var(--white);
+	overflow: hidden;
+}
+.custom_select .option_list li {
+	padding: 12px 16px;
+	line-height: 24px;
+	border-top: 1px solid var(--border-color);
+	color: var(--on-background-secondary-color);
+}
+.custom_select .option_list li:first-child {
+	border-top: 0 none;
+}
+.custom_select.active .select_body {
+	border-radius: 8px 8px 0 0;
+}
+.custom_select.active .option_list {
+	display: block;
+}
+
 /* pages */
 /* input_box */
 .input_box {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import Signup from "./pages/Signup";
 import ValidateEmail from "./pages/ValidateEmail";
 import NewPassword from "./pages/NewPassword";
 import BoardList from "./pages/BoardList";
+import Home from "./pages/Home";
 
 function App() {
 	return (
@@ -18,6 +19,7 @@ function App() {
 					<Nav />
 					<main className="container">
 						<Routes>
+							<Route path="/" element={<Home/>}/>
 							<Route path="/login" element={<Login />} />
 							<Route path="/signup" element={<Signup />} />
 							<Route path="/validateEmail" element={<ValidateEmail />} />

--- a/client/src/components/SelectBox.tsx
+++ b/client/src/components/SelectBox.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { useState, useRef, useEffect } from "react";
+import "../App.css";
+
+export interface SelectProps {
+	id?: string;
+	selectLabel: string;
+	isLabel: boolean; //label의 유무를 나타냅니다.
+	selectItem: string[];
+	placeHolder: string;
+}
+
+const SelectBox = ({
+	id,
+	selectLabel,
+	isLabel,
+	selectItem,
+	placeHolder,
+}: SelectProps) => {
+	const [nowValue, setNowValue] = useState(placeHolder);
+	const [isOpen, setIsOpen] = useState(false);
+	const customSelectRef = useRef<HTMLDivElement | null>(null);
+	//셀렉트 박스 외부 클릭시 닫힘
+	const handleClickAnother = (event: MouseEvent) => {
+		if (
+			customSelectRef.current &&
+			!customSelectRef.current.contains(event.target as Node)
+		) {
+			setIsOpen(false);
+		}
+	};
+	//메모리 누수 방지 처리: 컴포넌트가 마운트 될 때 이벤트를 등록하고, 이외에는 제거
+	useEffect(() => {
+		document.addEventListener("click", handleClickAnother);
+		return () => {
+			document.removeEventListener("click", handleClickAnother);
+		};
+	});
+	const handleClickSelectBody = () => {
+		setIsOpen(!isOpen);
+	};
+	const handleClickListItem = (event: React.MouseEvent<HTMLLIElement>) => {
+		setNowValue((event.target as HTMLLIElement).innerText);
+		setIsOpen(false);
+	};
+
+	return (
+		<div className="select_wrap" id={id}>
+			{/* 기본 select */}
+			{/* <div className="origin_select">
+				{isLabel ? <label htmlFor={id}>{selectLabel}</label> : null}
+				<select>
+					<option value="">{placeHolder}</option>
+					{selectItem.map((value, idx) => (
+						<option value={value} key={idx}>
+							{value}
+						</option>
+					))}
+				</select>
+			</div> */}
+			<div
+				className={`custom_select ${isOpen ? "active" : null}`}
+				ref={customSelectRef}
+			>
+				{isLabel ? <p className="label">{selectLabel}</p> : null}
+				<div className="select_body" onClick={handleClickSelectBody}>
+					{nowValue}
+				</div>
+				<ul className="option_list">
+					{selectItem.map((value, idx) => (
+						<li
+							key={idx}
+							onClick={(event) => {
+								handleClickListItem(event);
+							}}
+						>
+							{value}
+						</li>
+					))}
+				</ul>
+			</div>
+		</div>
+	);
+};
+export default SelectBox;

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,0 +1,17 @@
+import SelectBox from "../components/SelectBox";
+
+const Home = () => {
+	const selectItem1 = ["값1", "값2", "값3"];
+	return (
+		<div>
+			<SelectBox
+				id="test1"
+				selectLabel="테스트"
+				isLabel={true}
+				selectItem={selectItem1}
+				placeHolder="선택하세요"
+			/>
+		</div>
+	);
+};
+export default Home;


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 공통으로 사용할 커스텀 셀렉트박스(드롭다운)를 제작하였습니다.
- 셀렉트 박스 클릭시 하위 메뉴 나타남
- 내부의 값 클릭시 해당값으로 셀렉트 박스 상단의 값 변경
- 셀렉트 박스 상단을 다시 클릭하거나 셀렉트 박스 외의 영역을 클릭하면 하위 메뉴 사라짐

# 느낀 점 및 어려운 점
## 느낀 점
- 처음에 어떤 props를 받아야 하나 고민이 되었으나 일단은 필요한 요소만 작성하고 필요시 추가하기로 하였습니다.
- 필요한 기능이 많아질 수 있으므로 일단 의사코드로 필요한 기능과 동작을 정리하여 차근차근 진행하였습니다.
``` 
의사코드
1. 셀렉트박스 상단(바디)를 클릭하면: 
  - 하위 메뉴가 토글되어야 한다.
  - 셀렉트박스가 닫힐 때는 현재값을 유지한 채 하위메뉴가 사라져야 한다.
2. 셀렉트박스 바의 초기값은 placeholder이다.
3. 셀렉트박스 내의 하위 메뉴를 클릭하면:
  - 그 값이 현재값으로 설정되어야 한다.
  - 현재값으로 바디의 값이 변경되어야 한다.
  - 하위 메뉴가 사라져야 한다.
```
## 어려웠던 점
- 외부 클릭시 닫히도록 하려면 useRef로 설정한 타겟이 있는지, 그리고 내부의 요소를 클릭하지 않았는지 확인해야합니다. 그런데 그 과정에서 타입스크립트 타입 에러가 몇 가지 떠서 해결하느라 좀 어려웠습니다.
- ref.current의 타입이 never로 contains 메서드를 사용할 수 없다고 해서, ref의 타입을 명시해주어야 했습니다. 때문에 `HTMLDivElement`또는 `null` 타입으로 명시해주었습니다.
- `ref.current.contains(event.target)`에서 event.target 역시 타입을 명시해주어야 했습니다. `event.target as Node`로 명시해주니 이벤트가 정상적으로 작동되었습니다.
- 외부를 클릭했을 때 닫히도록 하려면 document 객체에 이벤트를 등록해야 하는데, 메모리 누수를 방지하려면 등록된 이벤트를 제거해야 합니다. 이 부분은 useEffect를 사용해 컴포넌트가 마운트 될 때 이벤트를 등록하고, 그렇지 않을 때는 이벤트를 제거하도록 아래와 같은 코드를 사용했습니다.
```tsx
useEffect(() => {
	document.addEventListener("click", handleClickAnother);
	return () => {
		document.removeEventListener("click", handleClickAnother);
	};
});
```

# [option] 관련 알림사항
셀렉트박스가 들어간 화면 때문에 화면 작업을 잠시 멈추고 공통 셀렉트 박스를 작업했으므로, 이후에는 화면 작업을 계속할 예정입니다.
