### PR TITLE
[feat/fe-userPage] 유저 정보 페이지 컴포넌트 생성

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -85,6 +85,7 @@ body {
 	max-width: 1100px;
 	padding: 72px 40px;
 	margin: 0 auto;
+	overflow: auto;
 }
 /* common */
 h2 {
@@ -185,7 +186,7 @@ label {
 input {
 	border: 1px solid var(--border-color);
 	border-radius: var(--br-md);
-	background: var(--white);
+	background-color: var(--white);
 	font-size: var(--fs-normal);
 	color: var(--on-background-color);
 	padding: 0 16px;
@@ -471,7 +472,7 @@ header .header_button_wrap .header_links.active {
 	border-radius: var(--br-md);
 	box-shadow: var(--bs-layer1);
 }
-.board_box .category_tag {
+.category_tag {
 	width: fit-content;
 	padding: 4px 8px;
 	border-radius: var(--br-sm);
@@ -479,21 +480,21 @@ header .header_button_wrap .header_links.active {
 	font-size: var(--fs-caption-sm);
 	color: var(--primary-color);
 }
-.board_box .board_date {
+.board_date {
 	font-family: "Roboto";
 	font-size: var(--fs-caption);
 	color: var(--on-background-secondary-color);
 }
-.board_box .board_writer {
+.board_writer {
 	font-size: var(--fs-caption);
 	color: var(--on-background-secondary-color);
 }
-.board_box .info_item {
+.info_item {
 	display: flex;
 	align-items: center;
 	margin-left: 8px;
 }
-.board_box .info_item .icon {
+.info_item .icon {
 	font-size: 0;
 	display: inline-block;
 	width: 16px;
@@ -503,15 +504,15 @@ header .header_button_wrap .header_links.active {
 	background-position: center;
 	overflow: hidden;
 }
-.board_box .info_item .info {
+.info_item .info {
 	font-family: "Roboto";
 	font-size: var(--fs-caption);
 	color: var(--on-background-secondary-color);
 }
-.board_box .info_item.comments_info .icon {
+.info_item.comments_info .icon {
 	background-image: url("./assets/icon_sms.svg");
 }
-.board_box .info_item.votes_info .icon {
+.info_item.votes_info .icon {
 	background-image: url("./assets/icon_thumb_up.svg");
 }
 /* board list */
@@ -546,6 +547,14 @@ header .header_button_wrap .header_links.active {
 	line-height: 100%;
 	font-size: var(--fs-h5);
 	font-weight: var(--fw-bold);
+}
+.board_item .comment {
+	margin: 8px 0;
+	line-height: 100%;
+	width: 100%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 /* board detail */
 .board_detail_box {
@@ -597,7 +606,7 @@ header .header_button_wrap .header_links.active {
 	left: 8px;
 	top: 2px;
 	margin: 0;
-	background: none;
+	background-color: transparent;
 }
 .board_detail_info .info_item .icon:checked + label {
 	background: var(--on-background-color);
@@ -630,4 +639,64 @@ header .header_button_wrap .header_links.active {
 	display: block;
 	width: 160px;
 	margin-left: auto;
+}
+/* user page */
+.user_profile {
+	display: flex;
+	align-items: center;
+	padding: 24px;
+	margin-bottom: 32px;
+	background: var(--white);
+	border-radius: var(--br-md);
+	box-shadow: var(--bs-layer1);
+}
+.profile_img_wrap {
+	width: 120px;
+	height: 120px;
+	border-radius: 100%;
+	margin-right: 16px;
+	background: var(--border-color); /* 임시 속성 */
+}
+.user_info_wrap {
+	margin-right: 16px;
+}
+.user_info_wrap .email {
+	margin-top: 4px;
+	color: var(--on-background-secondary-color);
+}
+.user_button_wrap {
+	margin-left: auto;
+}
+.user_button_wrap > button:first-child {
+	margin-right: 12px;
+}
+.user_written_wrap {
+	padding: 16px 0;
+	background: var(--white);
+	border-radius: var(--br-md);
+	box-shadow: var(--bs-layer1);
+}
+.tab_menu {
+	display: flex;
+	align-items: center;
+	border-bottom: 1px solid var(--border-color);
+}
+.tab_menu .tab_button {
+	position: relative;
+	padding: 12px 24px 14px 24px;
+}
+.tab_menu .tab_button.active {
+	color: var(--primary-color);
+}
+.tab_menu .tab_button.active::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	bottom: 0;
+	width: 100%;
+	height: 2px;
+	background-color: var(--primary-color);
+}
+.tab_content ul li {
+	border-bottom: 1px solid var(--border-color);
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import ValidateEmail from "./pages/ValidateEmail";
 import NewPassword from "./pages/NewPassword";
 import BoardList from "./pages/BoardList";
 import BoardDetail from "./pages/BoardDetail";
+import UserPage from "./pages/UserPage";
 
 function App() {
 	return (
@@ -27,6 +28,7 @@ function App() {
 							<Route path="/newPassword" element={<NewPassword />} />
 							<Route path="/board" element={<BoardList />} />
 							<Route path="/board/detail" element={<BoardDetail />} />
+							<Route path="/user" element={<UserPage />} />
 						</Routes>
 					</main>
 				</div>

--- a/client/src/components/CommentItem.tsx
+++ b/client/src/components/CommentItem.tsx
@@ -1,0 +1,26 @@
+const CommentItem = () => {
+	return (
+		<div className="board_item">
+			<div className="board_item_element_wrap">
+				<a href="" className="link em">
+					게시글 바로가기
+				</a>
+				<div className="board_info">
+					<p className="info_item votes_info">
+						<span className="icon">득표수</span>
+						<span className="info">12</span>
+					</p>
+				</div>
+			</div>
+			<p className="comment">
+				작성한 댓글입니다. 이런 내용이 달렸어요 만약 2줄이 넘어가면 ... 으로
+				처리되지요 ...작성한 댓글입니다. 이런 내용이 달렸어요 만약 2줄이
+				넘어가면 ... 으로 처리되지요 ...
+			</p>
+			<div className="board_item_element_wrap">
+				<p className="board_date">2023.9.30</p>
+			</div>
+		</div>
+	);
+};
+export default CommentItem;

--- a/client/src/pages/UserPage.tsx
+++ b/client/src/pages/UserPage.tsx
@@ -1,0 +1,75 @@
+import Button from "../components/Button";
+import BoardItem from "../components/Boarditem";
+import CommentItem from "../components/CommentItem";
+
+const dummyData = {
+	id: 53,
+	title: "JPA란",
+	content: "~~~~~~",
+	files: [
+		{
+			originalFileName: "orca.jfif",
+			storedFileName: "ddfd5ebb-c490-4b9c-bdc0-75c2ccc9e437.jfif",
+			url: "https://jbaccount.s3.ap-northeast-2.amazonaws.com/post/ddfd5ebb-c490-4b9c-bdc0-75c2ccc9e437.jfif",
+		},
+	],
+	voteCount: 0,
+	voteStatus: false,
+	member: {
+		id: 1,
+		nickname: "운영자",
+	},
+	createdAt: "2023-09-07T18:48:14.6994829",
+	modifiedAt: "2023-09-07T18:48:14.6994829",
+};
+
+const UserPage = () => {
+	return (
+		<div className="user_page_wrap">
+			<div className="user_profile">
+				<div className="profile_img_wrap"></div>
+				<div className="user_info_wrap">
+					<p className="title_h4">User 닉네임</p>
+					<p className="email">jbaccount@gmail.com</p>
+				</div>
+				<div className="user_button_wrap">
+					<Button
+						buttonType="another"
+						buttonSize="big"
+						buttonLabel="사용자 정보 수정"
+					/>
+					<Button
+						buttonType="another"
+						buttonSize="big"
+						buttonLabel="관리자 페이지"
+					/>
+				</div>
+			</div>
+			<div className="user_written_wrap">
+				<div className="tab_menu">
+					<div className="tab_button">작성글</div>
+					<div className="tab_button active">댓글</div>
+				</div>
+				<div className="tab_content">
+					<ul className="board">
+						<li>
+							<BoardItem data={dummyData} />
+						</li>
+						<li>
+							<BoardItem data={dummyData} />
+						</li>
+					</ul>
+					<ul className="comment">
+						<li>
+							<CommentItem />
+						</li>
+						<li>
+							<CommentItem />
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	);
+};
+export default UserPage;


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 유저 정보 페이지 작업
- 유저 정보 중 유저가 작성한 댓글 목록 아이템 컴포넌트 추가
- 기존 스타일 수정: 겹치는 스타일 공통 처리

# 느낀 점 및 어려운 점
- 크게 어려운 점은 없었습니다.
- 댓글 목록 아이템과 기존 게시글 목록 아이템의 스타일이 비슷합니다. 일단은 컴포넌트를 별개로 생성하여 사용했으나 추후에 api 연결시 boardItem 컴포넌트와 commentItem 컴포넌트를 합칠 수도 있습니다.

# [option] 관련 알림사항
- 페이지네이션 컴포넌트는 별개로 생성하여 추가할 예정입니다.
