### PR TITLE
[feat/fe-validate] 유효성 검사 기능 추가

### DIFF
--- a/client/src/assets/validater.ts
+++ b/client/src/assets/validater.ts
@@ -1,0 +1,30 @@
+export interface ValidatorStatus {
+	value: number | string; //값
+	isRequired: boolean; //필수 여부
+	valueType: "email" | "password" | "nickname"; //값 종류
+}
+
+export function validator(validateStatus: ValidatorStatus): boolean {
+	let isValid = true;
+
+	//필수 여부 확인
+	const target = validateStatus.value.toString();
+	if (validateStatus.isRequired) {
+		isValid = isValid && target.trim().length !== 0;
+	}
+	//주어진 값의 종류 판별 후 검사
+	let reg: RegExp;
+	switch (validateStatus.valueType) {
+		case "email":
+			reg = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
+			break;
+		case "password":
+			reg = /(?=.*\d)(?=.*[a-zA-Z])(?=.*[~!@]).{8,20}/;
+			break;
+		case "nickname":
+			reg = /(?=.*\d)|(?=.*[a-zA-Z])|(?=.*[가-힣]).{2,8}/;
+			break;
+	}
+	isValid = isValid && reg.test(target);
+	return isValid;
+}

--- a/client/src/components/Input.tsx
+++ b/client/src/components/Input.tsx
@@ -1,19 +1,21 @@
-import React from "react";
+import React, { ChangeEvent } from "react";
 import "../App.css";
 
 export interface InputProps {
-	InputLabel: string;
+	InputLabel: string; //label명
 	isLabel: boolean; //label의 유무를 나타냅니다.
+	//input 속성
 	inputAttr: {
 		type: string;
 		placeholder: string;
 		id?: string;
 	};
 	errorMsg?: string;
-	children?: React.ReactNode;
+	children?: React.ReactNode; //버튼이 포함된 경우
+	setInputValue?: (value: string) => void; //값 설정 함수
+	inputValue?: string; //값
+	isError?: boolean; //에러 여부
 }
-
-let count = 0;
 
 const Input = ({
 	InputLabel,
@@ -21,8 +23,15 @@ const Input = ({
 	errorMsg,
 	inputAttr,
 	children,
+	setInputValue,
+	inputValue,
+	isError,
 }: InputProps) => {
-	const id = `jb-input-${count + 1}` ?? inputAttr.id;
+	const id = `jb-input-${Math.random()}` ?? inputAttr.id;
+	const handleOnchange = (event: ChangeEvent<HTMLInputElement>) => {
+		if (setInputValue !== undefined)
+			setInputValue((event.target as HTMLInputElement)?.value);
+	};
 	return (
 		<div className="input_wrap">
 			{isLabel ? <label htmlFor={id}>{InputLabel}</label> : null}
@@ -31,65 +40,15 @@ const Input = ({
 					id={id}
 					type={inputAttr.type}
 					placeholder={inputAttr.placeholder}
+					onChange={handleOnchange}
+					value={inputValue}
+					className={isError ? "error" : ""}
 				/>
 				{children && children}
 			</div>
 
-			{errorMsg ? <p className="error_msg">{errorMsg}</p> : null}
+			{isError ? <p className="error_msg">{errorMsg}</p> : null}
 		</div>
 	);
 };
 export default Input;
-
-///////////////
-
-// import colors from "_tosslib/constants/colors";
-// import useId from "_tosslib/hooks/useId";
-// import {
-// 	Children,
-// 	cloneElement,
-// 	ForwardedRef,
-// 	forwardRef,
-// 	HTMLAttributes,
-// 	InputHTMLAttributes,
-// 	ReactElement,
-// 	ReactNode,
-// } from "react";
-
-// interface InputProps extends HTMLAttributes<HTMLDivElement> {
-// 	label?: ReactNode;
-// 	children: ReactElement;
-// 	bottomText?: string;
-// }
-
-// export function Input({ label, children, bottomText, ...props }: InputProps) {
-// 	const child = Children.only(children); //하위 요소를 하나만 받는다
-// 	const generatedId = useId("input"); //커스텀 훅을 사용해 id를 생성
-// 	const id = child.props.id ?? generatedId; //child의 id가 없을 경우 기본값으로 훅으로 생성된 id로 설정한다.
-// 	const isError: boolean = child.props.error ?? false; //왜 있지.. 에러가 있다면 표시, 기본값은 false
-
-// 	return (
-// 		<div {...props}>
-// 			<label htmlFor={id}>{label}</label>
-// 			{cloneElement(child, {
-// 				id,
-// 				...child.props,
-// 			})}
-// 			{bottomText != null ? <p>{bottomText}</p> : null}
-// 		</div>
-// 	);
-// }
-
-// interface TextFieldProps
-// 	extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
-// 	error?: boolean;
-// }
-
-// Input.TextField = forwardRef(
-// 	(
-// 		{ error, ...props }: TextFieldProps,
-// 		ref: ForwardedRef<HTMLInputElement>
-// 	) => {
-// 		return <input ref={ref} {...props} />;
-// 	}
-// );

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,7 +1,48 @@
 import Input from "./../components/Input";
 import Button from "./../components/Button";
+import { validator, ValidatorStatus } from "../assets/validater";
+import { useState } from "react";
 
 const Login = () => {
+	const [value, setValue] = useState({
+		email: "",
+		password: "",
+	});
+	const [isError, setIsError] = useState({
+		email: false,
+		password: false,
+	});
+	const setEmailValue = (value: string) => {
+		setValue((prevState) => ({
+			...prevState,
+			email: value,
+		}));
+	};
+	const setPasswordValue = (value: string) => {
+		setValue((prevState) => ({
+			...prevState,
+			password: value,
+		}));
+	};
+	//유효성 검사
+	const validatorStatusEmail: ValidatorStatus = {
+		value: value.email,
+		isRequired: true,
+		valueType: "email",
+	};
+	const validatorStatusPassword: ValidatorStatus = {
+		value: value.password,
+		isRequired: true,
+		valueType: "password",
+	};
+	const handleOnclick = () => {
+		setIsError((prevState) => ({
+			...prevState,
+			email: !validator(validatorStatusEmail),
+			password: !validator(validatorStatusPassword),
+		}));
+	};
+
 	return (
 		<div className="input_box login_box col_4">
 			<h3 className="title_h3">로그인</h3>
@@ -11,14 +52,25 @@ const Login = () => {
 					isLabel={true}
 					errorMsg="올바른 이메일을 입력해 주세요."
 					inputAttr={{ type: "text", placeholder: "이메일을 입력하세요" }}
+					setInputValue={setEmailValue}
+					inputValue={value.email}
+					isError={isError.email}
 				/>
 				<Input
 					InputLabel="비밀번호"
 					isLabel={true}
 					errorMsg="올바른 비밀번호를 입력해 주세요."
 					inputAttr={{ type: "password", placeholder: "비밀번호를 입력하세요" }}
+					setInputValue={setPasswordValue}
+					inputValue={value.password}
+					isError={isError.password}
 				/>
-				<Button buttonType="primary" buttonSize="big" buttonLabel="로그인" />
+				<Button
+					buttonType="primary"
+					buttonSize="big"
+					buttonLabel="로그인"
+					onClick={handleOnclick}
+				/>
 			</div>
 		</div>
 	);

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -1,7 +1,61 @@
+import { useState } from "react";
 import Input from "./../components/Input";
 import Button from "./../components/Button";
+import { validator, ValidatorStatus } from "../assets/validater";
 
 const Signup = () => {
+	const [value, setValue] = useState({
+		email: "",
+		password: "",
+		nickname: "",
+	});
+	const [isError, setIsError] = useState({
+		email: false,
+		password: false,
+		nickname: false,
+	});
+	const setEmailValue = (value: string) => {
+		setValue((prevState) => ({
+			...prevState,
+			email: value,
+		}));
+	};
+	const setPasswordValue = (value: string) => {
+		setValue((prevState) => ({
+			...prevState,
+			password: value,
+		}));
+	};
+	const setNicknameValue = (value: string) => {
+		setValue((prevState) => ({
+			...prevState,
+			nickname: value,
+		}));
+	};
+	//유효성 검사
+	const validatorStatusEmail: ValidatorStatus = {
+		value: value.email,
+		isRequired: true,
+		valueType: "email",
+	};
+	const validatorStatusPassword: ValidatorStatus = {
+		value: value.password,
+		isRequired: true,
+		valueType: "password",
+	};
+	const validatorStatusNickname: ValidatorStatus = {
+		value: value.nickname,
+		isRequired: true,
+		valueType: "nickname",
+	};
+	const handleOnclick = () => {
+		setIsError((prevState) => ({
+			...prevState,
+			email: !validator(validatorStatusEmail),
+			password: !validator(validatorStatusPassword),
+			nickname: !validator(validatorStatusNickname),
+		}));
+	};
 	return (
 		<div className="input_box sign_box col_4">
 			<h3 className="title_h3">회원가입</h3>
@@ -11,6 +65,9 @@ const Signup = () => {
 					isLabel={true}
 					errorMsg="올바른 이메일을 입력해 주세요."
 					inputAttr={{ type: "text", placeholder: "이메일을 입력하세요" }}
+					setInputValue={setEmailValue}
+					inputValue={value.email}
+					isError={isError.email}
 				/>
 				<Button
 					buttonType="primary"
@@ -26,6 +83,9 @@ const Signup = () => {
 					isLabel={true}
 					errorMsg="비밀번호는 8~20자의 영문, 숫자가 포함되어야 합니다. "
 					inputAttr={{ type: "password", placeholder: "비밀번호를 입력하세요" }}
+					setInputValue={setPasswordValue}
+					inputValue={value.password}
+					isError={isError.password}
 				/>
 				<Input
 					InputLabel="비밀번호 확인"
@@ -44,6 +104,9 @@ const Signup = () => {
 						type: "text",
 						placeholder: "닉네임을 입력하세요",
 					}}
+					setInputValue={setNicknameValue}
+					inputValue={value.nickname}
+					isError={isError.nickname}
 				>
 					<Button
 						buttonType="another"
@@ -51,7 +114,12 @@ const Signup = () => {
 						buttonLabel="중복 확인"
 					/>
 				</Input>
-				<Button buttonType="primary" buttonSize="big" buttonLabel="로그인" />
+				<Button
+					buttonType="primary"
+					buttonSize="big"
+					buttonLabel="회원가입"
+					onClick={handleOnclick}
+				/>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 유효성 검사 함수 추가
- 유효성 검사 추가로 인한 input 공통 컴포넌트 수정
- 회원가입, 로그인 유효성 검사 기능 추가

# 느낀 점 및 어려운 점
## 어려웠던 점
- 유효성 검사할 때 필요한 값들을 객체로 함수에 전달해주면 유효성 여부를 판별해줍니다. 이 때 타입스크립트가 넘긴 객체를 오류로 인식해서 조금 애를 먹었는데 간단히 유효성 검사시 설정한 interface를 타입으로 설정해주니 해결되었습니다. 
```tsx
const validatorStatusEmail: ValidatorStatus = {
    value: value.email,
    isRequired: true,
    valueType: "email",
};
```   
- input 컴포넌트를 공통으로 사용하다보니 유효성 검사 기능을 어디까지 공통으로 정해야 할지 고민이 되었습니다. 유효성 검사 내용은 input마다 다르고(이메일, 닉네임, 입력한 비밀번호와의 일치 여부 등등...) 에러 표시 스타일은 같기 때문에 onChange, error 판별만 공통으로 사용하고, 유효성 검사는 외부에서 따로 진행하는 것으로 처리하였습니다.
- 유효성 검사를 테스트할 때 마지막의 input 에러만 정상적으로 표시되는 문제가 있었습니다. 확인해보니 useState의 set함수는 비동기적으로 작동하기 때문에 생기는 문제였습니다. 그래서 set함수에 함수 형태로 이전 상태를 불러와 결과를 반영하도록 작업했더니 해결되었습니다.  
```tsx
const handleOnclick = () => {
	setIsError((prevState) => ({
		...prevState,
		email: !validator(validatorStatusEmail),
		password: !validator(validatorStatusPassword),
		nickname: !validator(validatorStatusNickname),
	}));
};
```

# [option] 관련 알림사항
로그인 및 회원가입 API연결을 시도하려고 합니다. AWS로 잘못 시도했다가 과금 등의 문제가 생길까봐 일단 테스트 전까지 다른 작업부터 하도록 하겠습니다.
