### PR TITLE
[feat/fe-signupAPI] 회원가입 API 연결

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/react-router-dom": "^5.3.3",
+    "axios": "^1.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -2,9 +2,10 @@ import { useState } from "react";
 import Input from "./../components/Input";
 import Button from "./../components/Button";
 import { validator, ValidatorStatus } from "../assets/validater";
+import axios from "axios";
 
 const Signup = () => {
-	const [value, setValue] = useState({
+	const [form, setForm] = useState({
 		email: "",
 		password: "",
 		nickname: "",
@@ -15,46 +16,61 @@ const Signup = () => {
 		nickname: false,
 	});
 	const setEmailValue = (value: string) => {
-		setValue((prevState) => ({
+		setForm((prevState) => ({
 			...prevState,
 			email: value,
 		}));
 	};
 	const setPasswordValue = (value: string) => {
-		setValue((prevState) => ({
+		setForm((prevState) => ({
 			...prevState,
 			password: value,
 		}));
 	};
 	const setNicknameValue = (value: string) => {
-		setValue((prevState) => ({
+		setForm((prevState) => ({
 			...prevState,
 			nickname: value,
 		}));
 	};
 	//유효성 검사
 	const validatorStatusEmail: ValidatorStatus = {
-		value: value.email,
+		value: form.email,
 		isRequired: true,
 		valueType: "email",
 	};
 	const validatorStatusPassword: ValidatorStatus = {
-		value: value.password,
+		value: form.password,
 		isRequired: true,
 		valueType: "password",
 	};
 	const validatorStatusNickname: ValidatorStatus = {
-		value: value.nickname,
+		value: form.nickname,
 		isRequired: true,
 		valueType: "nickname",
 	};
-	const handleOnclick = () => {
+	const handleSubmit = () => {
 		setIsError((prevState) => ({
 			...prevState,
 			email: !validator(validatorStatusEmail),
 			password: !validator(validatorStatusPassword),
 			nickname: !validator(validatorStatusNickname),
 		}));
+		if (isError.email || isError.password || isError.nickname) {
+			return;
+		}
+		console.log(form);
+
+		axios
+			.post("https://20f5-118-219-108-178.ngrok.io/members/sign-up", form, {
+				withCredentials: true,
+			})
+			.then((response) => {
+				console.log("회원가입 성공 !!!!", response.data);
+			})
+			.catch((error) => {
+				console.error("회원가입 실패 ㅠㅠㅠㅠ", error);
+			});
 	};
 	return (
 		<div className="input_box sign_box col_4">
@@ -66,7 +82,7 @@ const Signup = () => {
 					errorMsg="올바른 이메일을 입력해 주세요."
 					inputAttr={{ type: "text", placeholder: "이메일을 입력하세요" }}
 					setInputValue={setEmailValue}
-					inputValue={value.email}
+					inputValue={form.email}
 					isError={isError.email}
 				/>
 				<Button
@@ -84,7 +100,7 @@ const Signup = () => {
 					errorMsg="비밀번호는 8~20자의 영문, 숫자가 포함되어야 합니다. "
 					inputAttr={{ type: "password", placeholder: "비밀번호를 입력하세요" }}
 					setInputValue={setPasswordValue}
-					inputValue={value.password}
+					inputValue={form.password}
 					isError={isError.password}
 				/>
 				<Input
@@ -105,7 +121,7 @@ const Signup = () => {
 						placeholder: "닉네임을 입력하세요",
 					}}
 					setInputValue={setNicknameValue}
-					inputValue={value.nickname}
+					inputValue={form.nickname}
 					isError={isError.nickname}
 				>
 					<Button
@@ -118,7 +134,7 @@ const Signup = () => {
 					buttonType="primary"
 					buttonSize="big"
 					buttonLabel="회원가입"
-					onClick={handleOnclick}
+					onClick={handleSubmit}
 				/>
 			</div>
 		</div>

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -62,7 +62,7 @@ const Signup = () => {
 		console.log(form);
 
 		axios
-			.post("https://20f5-118-219-108-178.ngrok.io/members/sign-up", form, {
+			.post("http://localhost:8080/members/sign-up", form, {
 				withCredentials: true,
 			})
 			.then((response) => {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4565,6 +4565,15 @@ axe-core@^4.6.2:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
 
+axios@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.1.tgz#11fbaa11fc35f431193a9564109c88c1f27b585f"
+  integrity sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^3.1.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz"
@@ -6812,6 +6821,11 @@ follow-redirects@^1.0.0:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz"
@@ -6876,6 +6890,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -10350,7 +10373,7 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==

--- a/server/src/main/java/com/jbaacount/config/SecurityConfig.java
+++ b/server/src/main/java/com/jbaacount/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -23,6 +24,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
@@ -43,7 +45,7 @@ public class SecurityConfig
                 .headers((headers) ->
                         headers.frameOptions((frameOptions) -> frameOptions.disable()))
                 .csrf(csrf -> csrf.disable())
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .cors(Customizer.withDefaults())
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .formLogin(formLogin -> formLogin.disable())
                 .sessionManagement(management -> management
@@ -53,6 +55,8 @@ public class SecurityConfig
                                 .accessDeniedHandler(new CustomAccessDeniedHandler())
                                 .authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .requestMatchers(HttpMethod.GET).permitAll()
                         .requestMatchers(HttpMethod.PATCH, "/members/help/reset-password").permitAll()
                         .requestMatchers(HttpMethod.POST, "/members/login", "/members/sign-up").permitAll()
@@ -73,12 +77,13 @@ public class SecurityConfig
     }
 
 
-    public CorsConfigurationSource corsConfigurationSource()
+    @Bean
+    CorsConfigurationSource corsConfigurationSource()
     {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:8080"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
         configuration.setAllowedHeaders(List.of("*"));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"));
         configuration.setExposedHeaders(List.of("Authorization", "Refresh"));
         configuration.setAllowCredentials(true);
 

--- a/server/src/main/java/com/jbaacount/config/WebConfig.java
+++ b/server/src/main/java/com/jbaacount/config/WebConfig.java
@@ -1,3 +1,4 @@
+/*
 package com.jbaacount.config;
 
 import com.jbaacount.visitor.service.VisitorInterceptor;
@@ -18,3 +19,4 @@ public class WebConfig implements WebMvcConfigurer
         registry.addInterceptor(visitorInterceptor);
     }
 }
+*/

--- a/server/src/main/java/com/jbaacount/visitor/service/VisitorFilter.java
+++ b/server/src/main/java/com/jbaacount/visitor/service/VisitorFilter.java
@@ -1,26 +1,28 @@
-/*
 package com.jbaacount.visitor.service;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.filter.OncePerRequestFilter;
 
+import java.io.IOException;
 import java.time.LocalDate;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
-public class VisitorInterceptor implements HandlerInterceptor
+@Configuration
+public class VisitorFilter extends OncePerRequestFilter
 {
     private final RedisTemplate<String, String> redisTemplate;
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException
     {
         String ipAddress = getIp(request);
         String userAgent = request.getHeader("User-Agent");
@@ -35,7 +37,8 @@ public class VisitorInterceptor implements HandlerInterceptor
 
         log.info("ip address = {}", ipAddress);
         log.info("key = {}", key);
-        return true;
+
+        doFilterInternal(request, response, filterChain);
     }
 
     private String getIp(HttpServletRequest request)
@@ -59,4 +62,4 @@ public class VisitorInterceptor implements HandlerInterceptor
 
         return ip;
     }
-}*/
+}


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 회원가입 구현 위해 axios 추가
- 회원가입 axios POST 구문 추가

# 느낀 점 및 어려운 점
- 일단은 통신 테스트 위해 커밋합니다.

# [option] 관련 알림사항
## 클라이언트 테스트 방법
- 터미널에서 client 경로로 들어갑니다.
- (node 및 npm 또는 yarn 설치 필요합니다.) npm install 또는 yarn install 로 패키지 먼저 설치해주세요.
- 패키지 설치되면 yarn start하시면 localhost:3000으로 JBaccount 클라이언트 페이지에 접속이 가능합니다.
- 헤더 우측 상단 '회원가입'을 누르시고
- 이메일, 비밀번호 입력, 닉네임에만 각각 이메일, 비밀번호, 닉네임을 입력하시고 회원가입 버튼을 클릭하면 됩니다.
- F12(Mac은 Fn+F12)를 눌러 브라우저 개발자 도구의 console탭을 보면 어떤 에러가 뜨는지 알 수 있습니다.
