### PR TITLE
[feat/fe-pagination] 게시글 목록에 페이지네이션 기능 추가

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -33,6 +33,7 @@
 	/* font weight */
 	--fw-bold: 500;
 	--fw-normal: 400;
+	--fw-num-bold: 600;
 	/* line-height */
 	--lh-normal: calc(var(--fs-normal)+8);
 	--lh-h1: calc(var(--fs-h1)+8);
@@ -428,6 +429,48 @@ header .header_button_wrap .header_links.active {
 .nav a.unfold + .nav_menu.depth2 {
 	max-height: fit-content;
 	padding: 12px 0;
+}
+/* pagination */
+.pagination {
+	display: flex;
+	justify-content: center;
+	margin: 48px 0;
+}
+.pagination .arrow {
+	width: 24px;
+	height: 24px;
+	background: url(../src/assets/arrow_pagination.svg) no-repeat 0 0;
+	font-size: 0;
+	overflow: hidden;
+	cursor: pointer;
+}
+.pagination .arrow.right {
+	transform: rotate(180deg);
+}
+.pagination .page_num {
+	display: flex;
+	margin: 0 16px;
+}
+.pagination .page_num .page_button {
+	width: 24px;
+	height: 24px;
+	margin-left: 8px;
+	border-radius: var(--br-sm);
+	text-align: center;
+	line-height: 24px;
+	font-family: "Roboto";
+	font-weight: var(--fw-num-bold);
+	cursor: pointer;
+}
+.pagination .page_num .page_button:first-child {
+	margin-left: 0;
+}
+.pagination .page_num .page_button:hover {
+	background: var(--primary-container-color);
+}
+.pagination .page_num .page_button.active {
+	background: var(--primary-color);
+	color: var(--white);
 }
 
 /* pages */

--- a/client/src/assets/arrow_pagination.svg
+++ b/client/src/assets/arrow_pagination.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_531_3924" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<rect width="24" height="24" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_531_3924)">
+<path d="M13.9995 17.6538L8.3457 12L13.9995 6.34616L15.0534 7.39999L10.4534 12L15.0534 16.6L13.9995 17.6538Z" fill="#817F8B"/>
+</g>
+</svg>

--- a/client/src/data/boardListData.json
+++ b/client/src/data/boardListData.json
@@ -1,0 +1,170 @@
+{
+	"data": [
+		{
+			"board": {
+				"id": 1,
+				"name": "첫번째 게시판"
+			},
+			"category": {
+				"id": 1,
+				"name": "카테고리a"
+			},
+			"member": {
+				"id": 3,
+				"nickname": "회원2"
+			},
+			"id": 51,
+			"title": "게시글 테스트3",
+			"content": "12345",
+			"voteCount": 2,
+			"commentCount": 0,
+			"createdAt": "2023-11-06T11:26:13.097212"
+		},
+		{
+			"board": {
+				"id": 1,
+				"name": "첫번째 게시판"
+			},
+			"category": {
+				"id": 1,
+				"name": "카테고리a"
+			},
+			"member": {
+				"id": 2,
+				"nickname": "회원1"
+			},
+			"id": 50,
+			"title": "게시글 테스트",
+			"content": "12345",
+			"voteCount": 0,
+			"commentCount": 0,
+			"createdAt": "2023-11-06T11:26:13.096211"
+		},
+		{
+			"board": {
+				"id": 1,
+				"name": "첫번째 게시판"
+			},
+			"category": {
+				"id": 1,
+				"name": "카테고리a"
+			},
+			"member": {
+				"id": 4,
+				"nickname": "회원3"
+			},
+			"id": 49,
+			"title": "게시글 테스트2",
+			"content": "12345",
+			"voteCount": 0,
+			"commentCount": 0,
+			"createdAt": "2023-11-06T11:26:13.095212"
+		},
+		{
+			"board": {
+				"id": 1,
+				"name": "첫번째 게시판"
+			},
+			"category": {
+				"id": 1,
+				"name": "카테고리a"
+			},
+			"member": {
+				"id": 2,
+				"nickname": "회원1"
+			},
+			"id": 48,
+			"title": "게시글 테스트",
+			"content": "12345",
+			"voteCount": 0,
+			"commentCount": 0,
+			"createdAt": "2023-11-06T11:26:13.094212"
+		},
+		{
+			"board": {
+				"id": 1,
+				"name": "첫번째 게시판"
+			},
+			"category": {
+				"id": 1,
+				"name": "카테고리a"
+			},
+			"member": {
+				"id": 4,
+				"nickname": "회원3"
+			},
+			"id": 47,
+			"title": "게시글 테스트2",
+			"content": "12345",
+			"voteCount": 0,
+			"commentCount": 0,
+			"createdAt": "2023-11-06T11:26:13.093211"
+		},
+		{
+			"board": {
+				"id": 1,
+				"name": "첫번째 게시판"
+			},
+			"category": {
+				"id": 1,
+				"name": "카테고리a"
+			},
+			"member": {
+				"id": 2,
+				"nickname": "회원1"
+			},
+			"id": 46,
+			"title": "게시글 테스트",
+			"content": "12345",
+			"voteCount": 0,
+			"commentCount": 0,
+			"createdAt": "2023-11-06T11:26:13.092213"
+		},
+		{
+			"board": {
+				"id": 1,
+				"name": "첫번째 게시판"
+			},
+			"category": {
+				"id": 1,
+				"name": "카테고리a"
+			},
+			"member": {
+				"id": 4,
+				"nickname": "회원3"
+			},
+			"id": 45,
+			"title": "게시글 테스트2",
+			"content": "12345",
+			"voteCount": 0,
+			"commentCount": 0,
+			"createdAt": "2023-11-06T11:26:13.091211"
+		},
+		{
+			"board": {
+				"id": 1,
+				"name": "첫번째 게시판"
+			},
+			"category": {
+				"id": 1,
+				"name": "카테고리a"
+			},
+			"member": {
+				"id": 2,
+				"nickname": "회원1"
+			},
+			"id": 44,
+			"title": "게시글 테스트",
+			"content": "12345",
+			"voteCount": 0,
+			"commentCount": 0,
+			"createdAt": "2023-11-06T11:26:13.090213"
+		}
+	],
+	"pageInfo": {
+		"page": 2,
+		"size": 8,
+		"totalElements": 31,
+		"totalPages": 13
+	}
+}


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 여러 케이스 구현을 위해 api 연결을 제외하고 페이지네이션 기능을 구현하였습니다.
- 각 페이지 번호 클릭시 해당 페이지로 게시글 목록이 바뀜
- 이전 다음 버튼 클릭시 현재 활성화된 페이지를 기준으로 페이지 번호 버튼도 같이 바뀜
- 이전, 다음 버튼 페이지가 보이지 않는다면 버튼 구성도 같이 변경
(예를 들어 5에서 6으로 갈 때 페이지네이션 6~10으로 변경됨)

# 느낀 점 및 어려운 점
- 딱히 어려운 점은 없었고, 일단은 굴러가게, 그러나 생각나는 케이스는 모두 반영할 수 있도록 작업했습니다.
- 페이지네이션 기능을 어떻게 공통으로 작업할지, api 연결시 형태는 어떻게 하는 것이 좋을지 아직 큰 계획은 없으나 다른 작업 후 점진적으로 마이그레이션 할 예정입니다. 

# [option] 관련 알림사항
- 이후 다른 페이지의 페이지네이션도 작업해야 합니다.
- 만약 더 긴급한 기능이 있다면 그것부터 작업할 예정입니다.
- 리팩토링, 마이그레이션 등 일단은 구동되게 하고, 점진적으로 상향시켜 나갈 예정입니다. 
