### PR TITLE
[feat/fe-writeBoardAPI] 게시글 등록 API 연결

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -720,12 +720,12 @@ header .header_button_wrap .header_links.active {
 	margin-bottom: 48px;
 	border-bottom: 1px solid var(--border-color);
 }
-.board_input_title > input {
+.board_input_title input {
 	width: 100%;
 	font-size: var(--fs-h1);
 	border: 0 none;
 }
-.board_input_title > input::placeholder {
+.board_input_title input::placeholder {
 	font-family: "Noto Sans KR", sans-serif;
 	font-size: var(--fs-h1);
 	color: var(--border-color);

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -39,7 +39,7 @@ const Header = (props: HeaderProps) => {
 							프로필
 						</a>
 						<a
-							href=""
+							href="/board/write"
 							className="header_btns link_write"
 							title="클릭시 글쓰기 페이지로 이동합니다."
 						>

--- a/client/src/components/SelectBox.tsx
+++ b/client/src/components/SelectBox.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import { useState, useRef, useEffect } from "react";
 import "../App.css";
 
@@ -6,9 +6,10 @@ export interface SelectProps {
 	id?: string;
 	selectLabel?: string;
 	isLabel: boolean; //label의 유무를 나타냅니다.
-	selectItem: string[];
+	selectItem?: string[];
 	placeHolder: string;
 	setHandleStatus?: (status: string) => void;
+	children?: ReactNode;
 }
 
 const SelectBox = ({
@@ -18,6 +19,7 @@ const SelectBox = ({
 	selectItem,
 	placeHolder,
 	setHandleStatus,
+	children,
 }: SelectProps) => {
 	const [nowValue, setNowValue] = useState(placeHolder);
 	const [isOpen, setIsOpen] = useState(false);
@@ -71,16 +73,20 @@ const SelectBox = ({
 					{nowValue}
 				</div>
 				<ul className="option_list">
-					{selectItem.map((value, idx) => (
-						<li
-							key={idx}
-							onClick={(event) => {
-								handleClickListItem(event);
-							}}
-						>
-							{value}
-						</li>
-					))}
+					{children
+						? children
+						: selectItem
+						? selectItem.map((value, idx) => (
+								<li
+									key={idx}
+									onClick={(event) => {
+										handleClickListItem(event);
+									}}
+								>
+									{value}
+								</li>
+						  ))
+						: null}
 				</ul>
 			</div>
 		</div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,16 +1,9 @@
 import SelectBox from "../components/SelectBox";
 
 const Home = () => {
-	const selectItem1 = ["값1", "값2", "값3"];
 	return (
 		<div>
-			<SelectBox
-				id="test1"
-				selectLabel="테스트"
-				isLabel={true}
-				selectItem={selectItem1}
-				placeHolder="선택하세요"
-			/>
+			<h3>HOME</h3>
 		</div>
 	);
 };


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 게시글 등록 API 연결 및 기능 개선
- 셀렉트박스(드롭다운) 기능 개선: 게시글 및 카테고리 아이디 추출

# 느낀 점 및 어려운 점
- 로컬 서버로 작업하는데 서버 등록에 자꾸 에러가 떠서 해결하기 힘들었습니다. 원인은 알 수 없지만, 서버를 지우고 다시 코드를 가져와서 실행했더니 허무하게 되네요...
- 게시판 목록을 서버에서 가져와서 드롭다운 메뉴를 생성하는데, 화면에 보이지는 않지만 각 목록의 고유 아이디를 가져오는 방법을 많이 고민했습니다. 일단은 단순하게 일치 여부를 조회해서 찾는 걸로 만들었습니다.
  - 이 부분을 수정하고 싶었습니다. 기존 셀렉트박스는 공통 컴포넌트를 사용하는데, id를 별도로 삽입하려면 공통 컴포넌트를 수정해야 했습니다. 때문에 일단 컴포넌트의 자식 요소를 직접입력할 수 있도록 기능은 추가했는데, 이 id를 클릭시 가져오는 방법은 추후 리팩토링하려고 합니다.

# [option] 관련 알림사항
게시글 등록까지는 성공했지만, 아직 이미지 작성까지는 작업하지 않았습니다. 기본적인 게시글 CRUD가 급하기 때문에 이것 먼저 작업하도록 하겠습니다.
