### PR TITLE
[feat/fe-navAPI] 네비게이션 메뉴에 API 연결

### DIFF
--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -1,7 +1,8 @@
 import boardData from "./../data/boardData.json";
 import { ReactComponent as IconHome } from "./../assets/icon_home.svg";
 import iconArrowDown from "./../assets/icon_arrow_down.svg";
-import { MouseEvent } from "react";
+import { MouseEvent, useEffect, useState } from "react";
+import axios from "axios";
 
 const createMenuNode = (data: any[]) => {
 	return data.map((el: any, idx: number) => (
@@ -27,11 +28,22 @@ const createMenuNode = (data: any[]) => {
 
 const clickHandler = (event: React.MouseEvent<HTMLAnchorElement>): void => {
 	event.preventDefault();
-	console.log(event.currentTarget.classList);
 	event.currentTarget.classList.toggle("unfold");
 };
 
 const Nav = () => {
+	const api = process.env.REACT_APP_API_URL;
+	const [data, setData] = useState<any[]>([]);
+	useEffect(() => {
+		axios
+			.get(`${api}/board/all`)
+			.then((response) => {
+				setData(response.data);
+			})
+			.catch((error) => {
+				console.error("에러", error);
+			});
+	}, []);
 	return (
 		<nav className="nav">
 			<div className="home_link">
@@ -40,7 +52,7 @@ const Nav = () => {
 					HOME
 				</a>
 			</div>
-			<ul className="nav_menu depth1">{createMenuNode(boardData)}</ul>
+			<ul className="nav_menu depth1">{createMenuNode(data)}</ul>
 		</nav>
 	);
 };


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [ ]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
네비에기션 메뉴에 API를 연결하여 서버에 등록된 게시판들이 보이도록 했습니다.

# 느낀 점 및 어려운 점
어려운 점은 없었습니다. 다만 게시판 메뉴를 불러오는 곳이 네비게이션 외에도 한 군데 있어서 추후 이것을 통합하면 더 효율적일 것 같습니다.

# [option] 관련 알림사항
이제 메뉴의 각 게시판을 클릭하면 각 게시판의 게시글 목록을 볼 수 있도록 API를 연결할 생각입니다.
