### PR TITLE
[feat/fe-boardListAPI] 게시글 목록 관련 API 연결

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -580,6 +580,9 @@ header .header_button_wrap .header_links.active {
 	margin-right: 16px;
 }
 /* board list */
+.no_board_list {
+	padding: 48px 0;
+}
 .board_list_box {
 	padding: 0 16px;
 	margin-top: 16px;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
 							<Route path="/signup" element={<Signup />} />
 							<Route path="/validateEmail" element={<ValidateEmail />} />
 							<Route path="/newPassword" element={<NewPassword />} />
-							<Route path="/board" element={<BoardList />} />
+							<Route path="/board/:boardId" element={<BoardList />} />
 							<Route path="/board/detail" element={<BoardDetail />} />
 							<Route path="/board/write" element={<BoardWrite />} />
 							<Route path="/user" element={<UserPage />} />

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -2,20 +2,22 @@ import boardData from "./../data/boardData.json";
 import { ReactComponent as IconHome } from "./../assets/icon_home.svg";
 import iconArrowDown from "./../assets/icon_arrow_down.svg";
 import { MouseEvent, useEffect, useState } from "react";
+import { NavLink } from "react-router-dom";
 import axios from "axios";
 
 const createMenuNode = (data: any[]) => {
+	const api = process.env.REACT_APP_API_URL;
 	return data.map((el: any, idx: number) => (
 		<li key={idx} className="nav_menu_item">
 			{el.name ? (
-				<a href="" onClick={clickHandler}>
+				<NavLink to={`/board/${el.id}`} onClick={clickHandler}>
 					{el.name}
 					{el.categories && el.categories.length !== 0 ? (
 						<i className="toggle_updown">
 							<img src={iconArrowDown} alt="메뉴 펼치기 접기 토글 아이콘" />
 						</i>
 					) : null}
-				</a>
+				</NavLink>
 			) : (
 				<a href="">{el.categoryName}</a>
 			)}
@@ -27,7 +29,7 @@ const createMenuNode = (data: any[]) => {
 };
 
 const clickHandler = (event: React.MouseEvent<HTMLAnchorElement>): void => {
-	event.preventDefault();
+	//event.preventDefault();
 	event.currentTarget.classList.toggle("unfold");
 };
 

--- a/client/src/pages/BoardWrite.tsx
+++ b/client/src/pages/BoardWrite.tsx
@@ -5,7 +5,8 @@ import EditorUnit from "../components/EditorUnit";
 import boardData from "./../data/boardData.json";
 import Input from "../components/Input";
 import axios from "axios";
-import { useEffect, useState, useRef, ReactElement } from "react";
+import { useEffect, useState, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 
 interface FormType {
 	title: string;
@@ -17,6 +18,7 @@ interface FormType {
 const BoardWrite = () => {
 	const api = process.env.REACT_APP_API_URL;
 	const [accessToken, setAccessToken] = useState("");
+	const navigate = useNavigate();
 	const [data, setData] = useState<any[]>([]);
 	// const [selectItemBoard, setSeletItemBoard] = useState<any[]>([]);
 	useEffect(() => {
@@ -86,11 +88,10 @@ const BoardWrite = () => {
 				Authorization: `${localStorage.getItem("accessToken")}`,
 			},
 		};
-		console.log(formData);
 		axios
 			.post(`${api}/`, formData, postAxiosConfig)
-			.then((response) => {
-				console.log("글 작성 성공 !!!!", response.data);
+			.then((_) => {
+				navigate(`/board/${boardId}`);
 			})
 			.catch((error) => {
 				if (error.response) {
@@ -107,9 +108,6 @@ const BoardWrite = () => {
 				}
 				console.error("에러 구성:", error.config);
 			});
-	};
-	const handleWriteComplete = () => {
-		console.log(boardData);
 	};
 
 	return (


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 네비게이션 메뉴에 API 연결
- 게시글 목록 라우터 수정
- 게시글 목록 API 연결
- 게시글 등록 후 게시글 목록으로 페이지 이동 추가

# 느낀 점 및 어려운 점
- 게시글 목록의 라우터 경로 중에 유동적인 부분이 있다면 `:userId` 이런식으로 표시할 수 있습니다. 
- 테스트결과 게시글 목록 요청시 에러도 없었고, 게시판의 정보는 잘 불러왔지만, 실제 등록된 게시글이 있는데도 서버에서 data란이 비어서 오는 현상이 있었습니다. MySQL의 DB를 확인해봐도 게시글이 20개 가까이 쌓여있는 것을 확인했으나 서버에서는 게시글 정보를 보내지 않는 것을 확인했습니다. 
- 추후에 백엔드 측에서 API가 수정되면 게시글 목록 작업을 추가로 진행할 예정입니다.  

# [option] 관련 알림사항
해당 브랜치는 삭제하고 새로운 브랜치로 이어서 작업할 예정입니다. 그 전에 API가 수정되면 API 먼저 기존 작업부터 수정 반영하도록 하겠습니다.
