### PR TITLE
[feat/boardDetailEdit] 게시글 수정 페이지 추가, API 연결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import BoardDetail from "./pages/BoardDetail";
 import BoardWrite from "./pages/BoardWrite";
 import UserPage from "./pages/UserPage";
 import UserEdit from "./pages/UserEdit";
+import BoardDetailEdit from "./pages/BoardDetailEdit";
 
 function App() {
 	const [isLogin, setIsLogin] = useState(false);
@@ -38,7 +39,11 @@ function App() {
 								element={<BoardDetail />}
 							/>
 							<Route path="/board/write" element={<BoardWrite />} />
-							<Route path="/user" element={<UserPage />} />
+							<Route
+								path="/board/edit/:boardInfo/:postId"
+								element={<BoardDetailEdit />}
+							/>
+							<Route path="/user/:userId" element={<UserPage />} />
 							<Route path="/user/edit" element={<UserEdit />} />
 						</Routes>
 					</main>

--- a/client/src/assets/tokenActions.ts
+++ b/client/src/assets/tokenActions.ts
@@ -2,6 +2,9 @@ export const isAccessToken = () => {
 	const token = localStorage.getItem("accessToken");
 	return !!token;
 };
+export const getAccessToken = () => {
+	return localStorage.getItem("accessToken");
+};
 export const saveAccessToken = (token: string) => {
 	localStorage.setItem("accessToken", token);
 };

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -4,17 +4,43 @@ import { NavLink, useNavigate } from "react-router-dom";
 import iconMenu from "./../assets/icon_menu.svg";
 import iconWrite from "./../assets/edit_document.svg";
 import iconLogout from "./../assets/logout.svg";
-import { isAccessToken, removeAccessToken } from "../assets/tokenActions";
+import { getAccessToken, removeAccessToken } from "../assets/tokenActions";
+import axios from "axios";
 
 export interface HeaderProps {
 	isLogin: boolean;
 	setIsLogin: Dispatch<React.SetStateAction<boolean>>;
 }
+interface userData {
+	createdAt: string;
+	email: string;
+	id: number;
+	nickname: string;
+	profileImage: string | null;
+	score: number;
+	timeInfo: string;
+}
 const Header = (props: HeaderProps) => {
+	const api = process.env.REACT_APP_API_URL;
 	const navigate = useNavigate();
+	const [userData, setUserData] = useState<userData>();
 	useEffect(() => {
-		if (isAccessToken()) props.setIsLogin(true);
-		else props.setIsLogin(false);
+		if (getAccessToken()) {
+			let token = getAccessToken();
+			axios
+				.get(`${api}/api/v1/member/single-info`, {
+					headers: { Authorization: token },
+				})
+				.then((res) => {
+					setUserData(res.data.data);
+					props.setIsLogin(true);
+				})
+				.catch((error) => {
+					console.error("에러", error);
+					console.log("토큰이 인증되지 않았습니다.");
+					props.setIsLogin(false);
+				});
+		} else props.setIsLogin(false);
 	}, []);
 	const handleLogoutClick = () => {
 		removeAccessToken();
@@ -32,7 +58,7 @@ const Header = (props: HeaderProps) => {
 				{props.isLogin ? (
 					<>
 						<a
-							href=""
+							href={`/user/${userData?.id}`}
 							className="header_btns link_profile"
 							title="클릭시 내 프로필로 이동합니다."
 						>

--- a/client/src/pages/BoardDetail.tsx
+++ b/client/src/pages/BoardDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import Button from "../components/Button";
 import axios from "axios";
+import { getAccessToken } from "../assets/tokenActions";
 
 interface BoardDetailData {
 	postId: number;
@@ -20,8 +21,11 @@ interface BoardDetailData {
 const BoardDetail = () => {
 	const api = process.env.REACT_APP_API_URL;
 	const params = useParams();
+	const [boardId, boardName] = params.boardInfo!.split("-");
 	const [postData, setPostData] = useState<BoardDetailData>();
+	const [myMemberId, setmyMemberID] = useState<number>();
 	useEffect(() => {
+		const accessToken = getAccessToken();
 		axios
 			.get(`${api}/api/v1/post/${params.postId}`)
 			.then((response) => {
@@ -30,6 +34,17 @@ const BoardDetail = () => {
 			.catch((error) => {
 				console.error("에러", error);
 			});
+
+		if (accessToken) {
+			axios
+				.get(`${api}/api/v1/member/single-info`, {
+					headers: { Authorization: accessToken },
+				})
+				.then((res) => {
+					setmyMemberID(res.data.data.id);
+				})
+				.catch((_) => {});
+		}
 	}, []);
 
 	return (
@@ -60,14 +75,19 @@ const BoardDetail = () => {
 								</label>
 							</div>
 						</div>
-						<div className="writer_action">
-							<a href="" className="link">
-								수정
-							</a>
-							<a href="" className="link">
-								삭제
-							</a>
-						</div>
+						{myMemberId === postData.memberId ? (
+							<div className="writer_action">
+								<a
+									href={`/board/edit/${boardId}-${boardName}/${params.postId}`}
+									className="link"
+								>
+									수정
+								</a>
+								<a href="" className="link">
+									삭제
+								</a>
+							</div>
+						) : null}
 					</div>
 					<div
 						className="board_content"

--- a/client/src/pages/BoardDetailEdit.tsx
+++ b/client/src/pages/BoardDetailEdit.tsx
@@ -1,0 +1,183 @@
+import React, { ChangeEvent } from "react";
+import SelectBox from "../components/SelectBox";
+import Button from "../components/Button";
+import EditorUnit from "../components/EditorUnit";
+import Input from "../components/Input";
+import axios from "axios";
+import { useEffect, useState, useRef } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { getAccessToken } from "../assets/tokenActions";
+
+interface FormType {
+	title: string;
+	content: string;
+	categoryId?: number | string;
+}
+
+interface categoryDataType {
+	id: number;
+	name: string;
+	orderIndex: number;
+	adminOnly: boolean;
+}
+interface postData {
+	memberId: number;
+	boardId: number;
+	categoryId: number;
+	postId: number;
+	nickname: string;
+	title: string;
+	content: string;
+	files: any[];
+	voteCount: number;
+	voteStatus: boolean;
+	createdAt: string;
+}
+
+const BoardWrite = () => {
+	const api = process.env.REACT_APP_API_URL;
+	const [accessToken, setAccessToken] = useState("");
+	const navigate = useNavigate();
+	const [postdata, setPostData] = useState<postData>();
+	const params = useParams();
+	const [boardId, boardName] = params.boardInfo!.split("-");
+	const [categoryItem, setCategoryItem] = useState<categoryDataType[]>([]); //카테고리 목록
+	const [nowCategoryId, setNowCategoryId] = useState(0); //현재 선택된 카테고리 id
+	const [selectValueCategory, setSelectValueCategory] = useState(""); //현재 선택된 카테고리
+	const [titleValue, setTitleValue] = useState("");
+	const editorRef = useRef<any>(null); //작성된 내용
+	useEffect(() => {
+		//게시글 정보 받아오기
+		axios
+			.get(`${api}/api/v1/post/${params.postId}`)
+			.then((response) => {
+				const data = response.data.data;
+				setPostData(data);
+				setTitleValue(data.title);
+				editorRef.current?.getInstance().setHTML(data.content);
+			})
+			.catch((error) => {
+				console.error("에러", error);
+			});
+		//카테고리 목록 받아오기
+		axios
+			.get(`${api}/api/v1/category?board=${boardId}`)
+			.then((response) => {
+				setCategoryItem(response.data.data);
+			})
+			.catch((error) => {
+				console.error("에러", error);
+			});
+	}, []);
+	//카테고리 선택
+	const handleSelectCategory = (categoryName: string) => {
+		const matchedCategory: categoryDataType | undefined = categoryItem!.find(
+			(el: categoryDataType) => el.name === categoryName
+		);
+		setNowCategoryId(matchedCategory!.id);
+		setSelectValueCategory(categoryName);
+	};
+	//취소 클릭시 게시글로 이동
+	const cancelClickHandler = () => {
+		navigate(`/board/${boardId}-${boardName}/${params.postId}`);
+	};
+	//제출
+	const submitHandler = () => {
+		const editorData: string = editorRef.current!.getInstance().getHTML(); //작성된 데이터
+		const form: FormType =
+			nowCategoryId > 0
+				? {
+						title: titleValue,
+						content: editorData,
+						categoryId: nowCategoryId,
+				  }
+				: {
+						title: titleValue,
+						content: editorData,
+				  };
+
+		const formData = new FormData();
+		formData.append(
+			"data",
+			new Blob([JSON.stringify(form)], {
+				type: "application/json",
+			})
+		);
+		const postAxiosConfig = {
+			headers: {
+				"Content-Type": "multipart/form-data", // FormData를 사용할 때 Content-Type을 변경
+				Authorization: `${getAccessToken()}`,
+			},
+		};
+		axios
+			.patch(
+				`${api}/api/v1/post/update/${params.postId}`,
+				formData,
+				postAxiosConfig
+			)
+			.then((_) => {
+				navigate(`/board/${boardId}-${boardName}/${params.postId}`);
+			})
+			.catch((error) => {
+				if (error.response) {
+					// 서버 응답이 있을 경우 (에러 상태 코드가 반환된 경우)
+					console.error("서버 응답 에러:", error.response.data);
+					console.error("응답 상태 코드:", error.response.status);
+					console.error("응답 헤더:", error.response.headers);
+				} else if (error.request) {
+					// 요청이 전혀 되지 않았을 경우
+					console.error("요청 에러:", error.request);
+				} else {
+					// 설정에서 문제가 있어 요청이 전송되지 않은 경우
+					console.error("Axios 설정 에러:", error.message);
+				}
+				console.error("에러 구성:", error.config);
+			});
+	};
+
+	return (
+		<div className="board_box board_write_box">
+			<div className="board_write_head">
+				<div className="board_select_wrap">
+					{categoryItem.length !== 0 ? (
+						<SelectBox
+							isLabel={false}
+							selectItem={categoryItem.map((el: categoryDataType) => el.name)}
+							placeHolder="카테고리 선택"
+							setHandleStatus={handleSelectCategory}
+						/>
+					) : null}
+				</div>
+				<div className="board_input_title">
+					<Input
+						InputLabel="제목"
+						isLabel={false}
+						errorMsg="제목을 입력해 주세요."
+						inputAttr={{
+							type: "text",
+							placeholder: "게시글 제목을 입력하세요",
+						}}
+						setInputValue={setTitleValue}
+						inputValue={titleValue}
+					/>
+				</div>
+			</div>
+			<EditorUnit ref={editorRef} />
+			<div className="board_editor_button_wrap">
+				<Button
+					buttonType="primary"
+					buttonSize="big"
+					buttonLabel="수정 완료"
+					onClick={submitHandler}
+				/>
+				<Button
+					buttonType="no_em"
+					buttonSize="big"
+					buttonLabel="취소"
+					onClick={cancelClickHandler}
+				/>
+			</div>
+		</div>
+	);
+};
+export default BoardWrite;

--- a/client/src/pages/BoardWrite.tsx
+++ b/client/src/pages/BoardWrite.tsx
@@ -79,6 +79,10 @@ const BoardWrite = () => {
 		setNowCategoryId(matchedCategory.id);
 		setSelectValueCategory(category);
 	};
+	//취소 클릭시 목록으로 이동
+	const cancelClickHandler = () => {
+		navigate(`/board/${nowBoardData!.id}-${nowBoardData!.name}`);
+	};
 	//제출
 	const submitHandler = () => {
 		const boardId = nowBoardData!.id.toString(); //게시판 id
@@ -171,7 +175,12 @@ const BoardWrite = () => {
 					buttonLabel="작성 완료"
 					onClick={submitHandler}
 				/>
-				<Button buttonType="no_em" buttonSize="big" buttonLabel="취소" />
+				<Button
+					buttonType="no_em"
+					buttonSize="big"
+					buttonLabel="취소"
+					onClick={cancelClickHandler}
+				/>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 게시글 수정 페이지 추가, API 연결
- 로컬 스토리지에 저장된 토큰 자체를 가져오는 get함수 추가
- 헤더, 게시글 상세보기에서 현재 유저를 판별하는 기능 추가
- 게시글 작성 및 수정 중 취소시 목록으로 돌아가는 기능 추가

# 느낀 점 및 어려운 점
- 크게 어려운 점은 없었습니다. 그저 기능을 추가하는데 기존의 컴포넌트들이 영향을 받는 경우가 있어 수정을 반영하고, 그김에 코드를 좀 보완하느라 기능 자체만 만들 때보다는 시간이 걸렸습니다.
- 게시글의 작성자가 현재 유저일 경우에만 수정, 삭제할 수 있도록 작업했습니다. 그러려면 현재 API 정책상 토큰을 보내서 현재 유저의 정보를 받아오면 됩니다. 이는 게시글 상세보기 뿐만 아니라 헤더 컴포넌트에서도 유효한 토큰인지 아닌지 판별하는데 필요하므로 기존 컴포넌트의 코드를 파악하여 수정사항을 반영하였습니다.
-  게시글 수정 페이지는 게시글 작성 페이지와 비슷하면서도 다른데, 서버에 문자열로 저장된 게시글 내용을 가져와 에디터에 HTML방식으로 렌더링해줘야 한다는 점이 가장 큰 차이점입니다. 다행히 서버에 에디터의 HTML태그를 문자열로 보내는 방법과 비슷해서 금방 해결했습니다. 
- 게시글 수정시 게시글이 속한 게시판은 변경할 수 없지만 카테고리는 변경이 가능합니다. 유저에게는 카테고리의 이름만 보여야 하지만 서버에는 카테고리의 아이디를 전달해야 했으므로 카테고리의 아이디, 이름 모두가 필요합니다. 때문에 필요한 정보를 효율적으로 받아오도록 코드를 짜는게 중요했는데 다소 복잡해서 어려울 뻔 했습니다. 현재는 문제점을 발견하지 못했으나 추후에 테스트하면서 에러가 생긴다면 픽스하고 리팩토링할 예정입니다.   

# [option] 관련 알림사항
다음은 게시글 삭제를 작업할 예정입니다.
