### PR TITLE
[feat/userRank] 네비게이션 하단에 통계 영역(방문자수, 질문왕) 추가

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -70,21 +70,22 @@ body {
 	height: 100%;
 }
 .App {
-	display: flex;
-	flex-direction: column;
+	/* display: flex;
+	flex-direction: column; */
 	min-height: 100%;
 	background: var(--background-color);
 }
 .page_wrap {
-	display: flex;
-	flex: 1;
+	/* display: flex;
+	flex: 1; */
 	position: relative;
+	padding-left: 300px;
 }
 .page_wrap .container {
 	position: relative;
 	width: 100%;
 	max-width: 1100px;
-	padding: 72px 40px;
+	padding: 144px 40px 72px 40px;
 	margin: 0 auto;
 	overflow: auto;
 }
@@ -299,6 +300,9 @@ input.error {
 
 /* header */
 .header {
+	position: fixed;
+	top: 0;
+	left: 0;
 	display: flex;
 	align-items: center;
 	width: 100%;
@@ -306,6 +310,7 @@ input.error {
 	padding: 0 16px;
 	box-sizing: border-box;
 	background: var(--primary-color);
+	z-index: 2;
 }
 .header .button_navi {
 	width: 24px;
@@ -358,13 +363,20 @@ header .header_button_wrap .header_links.active {
 
 /* nav */
 .nav {
-	flex: 0 0 auto;
+	/* flex: 0 0 auto; */
+	position: fixed;
+	top: 0;
+	left: 0;
 	width: 300px;
-	padding: 16px 0;
+	height: 100%;
+	padding: 88px 0 16px 0;
 	background: var(--white);
 	box-shadow: var(--bs-layer1);
+	display: flex;
+	flex-direction: column;
 }
 .nav_menu {
+	flex: 1;
 	padding: 0 16px;
 }
 .nav a {
@@ -434,6 +446,55 @@ header .header_button_wrap .header_links.active {
 .nav a.unfold + .nav_menu.depth2 {
 	max-height: fit-content;
 	padding: 12px 0;
+}
+.nav_info_wrap {
+	padding: 24px 16px;
+}
+.nav_info_wrap .statistics {
+	display: flex;
+	margin-bottom: 24px;
+}
+.nav_info_wrap .statistics .info {
+	padding-left: 16px;
+}
+.nav_info_wrap .statistics .info.all {
+	padding-left: 0;
+	flex: 1;
+}
+.nav_info_wrap .statistics .info_title {
+	line-height: var(--lh-caption);
+	font-weight: var(--fw-bold);
+}
+.nav_info_wrap .statistics .info_content {
+	line-height: var(--lh-caption);
+	font-weight: var(--fw-bold);
+	font-size: var(--fs-caption);
+	color: var(--on-background-secondary-color);
+}
+.nav_info_wrap .user_rank {
+}
+.nav_info_wrap .user_rank .title {
+	font-weight: var(--fw-bold);
+	margin-bottom: 14px;
+}
+.nav_info_wrap .user_rank .user_rank_item {
+	display: flex;
+	align-items: center;
+}
+.nav_info_wrap .user_rank .user_rank_item .icon {
+	width: 24px;
+	height: 24px;
+	margin-right: 4px;
+}
+.nav_info_wrap .user_rank .user_rank_item .grade {
+	margin-right: 12px;
+	line-height: var(--lh-caption);
+	font-weight: var(--fw-bold);
+}
+.nav_info_wrap .user_rank .user_rank_item .user {
+	line-height: var(--lh-caption);
+	font-size: var(--fs-caption);
+	color: var(--on-background-secondary-color);
 }
 /* pagination */
 .pagination {

--- a/client/src/assets/icon_star.svg
+++ b/client/src/assets/icon_star.svg
@@ -1,0 +1,8 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_638_3590" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="25" height="24">
+<rect x="0.431641" width="24" height="24" fill="#7037F0"/>
+</mask>
+<g mask="url(#mask0_638_3590)">
+<path d="M6.25664 21L7.88164 13.975L2.43164 9.25L9.63164 8.625L12.4316 2L15.2316 8.625L22.4316 9.25L16.9816 13.975L18.6066 21L12.4316 17.275L6.25664 21Z" fill="#7037F0"/>
+</g>
+</svg>

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -4,6 +4,7 @@ import iconArrowDown from "./../assets/icon_arrow_down.svg";
 import { MouseEvent, useEffect, useState, Dispatch } from "react";
 import { NavLink } from "react-router-dom";
 import axios from "axios";
+import NavInfo from "./NavInfo";
 
 const createMenuNode = (data: any[]) => {
 	return data!.map((el: any, idx: number) => (
@@ -57,6 +58,7 @@ const Nav = () => {
 				</a>
 			</div>
 			<ul className="nav_menu depth1">{createMenuNode(data)}</ul>
+			<NavInfo />
 		</nav>
 	);
 };

--- a/client/src/components/NavInfo.tsx
+++ b/client/src/components/NavInfo.tsx
@@ -1,0 +1,68 @@
+import iconStar from "./../assets/icon_star.svg";
+import axios from "axios";
+import { useState, useEffect } from "react";
+
+const NavInfo = () => {
+	const api = process.env.REACT_APP_API_URL;
+	const [userRank, setUserRank] = useState<any[]>(["-", "-", "-"]);
+	const [visitorInfo, setVisitorInfo] = useState({
+		yesterday: 0,
+		today: 0,
+		total: 0,
+	});
+	useEffect(() => {
+		axios
+			.get(`${api}/api/v1/member/score`)
+			.then((response) => {
+				const length = response.data.data.length;
+				const newRank = userRank;
+				for (let i = 0; i < length; i++) {
+					newRank[i] = response.data.data[i];
+				}
+				setUserRank(newRank);
+			})
+			.catch((error) => {
+				console.error("에러", error);
+			});
+
+		axios
+			.get(`${api}/api/v1/visitor`)
+			.then((response) => {
+				setVisitorInfo(response.data.data);
+			})
+			.catch((error) => {
+				console.error("에러", error);
+			});
+	}, []);
+	return (
+		<div className="nav_info_wrap">
+			<div className="statistics">
+				<dl className="info all">
+					<dt className="info_title">전체 방문자</dt>
+					<dd className="info_content">{visitorInfo.total}</dd>
+				</dl>
+				<dl className="info">
+					<dt className="info_title">어제</dt>
+					<dd className="info_content">{visitorInfo.yesterday}</dd>
+				</dl>
+				<dl className="info">
+					<dt className="info_title">오늘</dt>
+					<dd className="info_content">{visitorInfo.today}</dd>
+				</dl>
+			</div>
+			<div className="user_rank">
+				<p className="title">이달의 질문왕</p>
+				<ul>
+					{userRank.map((el, idx) => (
+						<li className="user_rank_item" key={idx}>
+							<img src={iconStar} alt="별 아이콘" className="icon" />
+							<span className="grade">{`${idx + 1}등`}</span>
+							<span className="user">{el === "-" ? el : el.nickname}</span>
+						</li>
+					))}
+				</ul>
+			</div>
+		</div>
+	);
+};
+export default NavInfo;


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 네비게이션 하단에 통계 영역 추가, 이로인한 레이아웃 변경
- 방문자수, 질문왕 영역 퍼블리싱
- 방문자수, 질문왕 영역 API 연결

# 느낀 점 및 어려운 점
딱히 어려운 점은 없었고, 작업 내용이 많지 않아 퍼블리싱과 API 연결까지 한번에 작업하였습니다.

# [option] 관련 알림사항
이제 관리자 페이지 API 연결만 마무리하면 드디어 1차 배포에 들어갈 수 있습니다.
