### PR TITLE
[feat/adminAPI] 관리자 페이지 API 연결

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -85,6 +85,7 @@ body {
 	position: relative;
 	width: 100%;
 	max-width: 1100px;
+	min-height: 100vh;
 	padding: 144px 40px 72px 40px;
 	margin: 0 auto;
 	overflow: auto;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -68,6 +68,7 @@ function App() {
 								path="/user/:userId/edit"
 								element={<UserEdit userData={userData} />}
 							/>
+							<Route path="/admin" element={<Signup />} />
 						</Routes>
 					</main>
 				</div>

--- a/client/src/components/AdminBoardItem.tsx
+++ b/client/src/components/AdminBoardItem.tsx
@@ -7,6 +7,8 @@ import { ReactComponent as IconArrowDown } from "./../assets/icon_arrow_down.svg
 import { Draggable } from "react-beautiful-dnd";
 import { StrictModeDroppable as Droppable } from "./StrictModeDroppable";
 import AdminCategoryItem from "./AdminCategoryItem";
+import axios from "axios";
+import { getAccessToken } from "../assets/tokenActions";
 
 const InnerList = React.memo(function InnerList({
 	board,
@@ -24,7 +26,14 @@ const InnerList = React.memo(function InnerList({
 	));
 });
 
-function AdminBoardItem({ board, categories, index, editData }: any) {
+function AdminBoardItem({
+	board,
+	categories,
+	index,
+	editData,
+	fetchData,
+}: any) {
+	const api = process.env.REACT_APP_API_URL;
 	const [newCategory, setNewCategory] = useState("");
 	const [isEdit, setIsEdit] = useState(false);
 	const [boardName, setBoardName] = useState(board.name);
@@ -34,8 +43,31 @@ function AdminBoardItem({ board, categories, index, editData }: any) {
 	const setInputValueNewCategory = (value: string) => {
 		setNewCategory(value);
 	};
+	//카테고리 생성
 	const handleClickCreateCategory = () => {
-		console.log(board.id, newCategory);
+		const newCategoryData = {
+			name: newCategory,
+			isAdminOnly: false,
+		};
+		const postAxiosConfig = {
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `${getAccessToken()}`,
+			},
+		};
+		axios
+			.post(
+				`${api}/api/v1/admin/manage/category/create?board=${board.id}`,
+				newCategoryData,
+				postAxiosConfig
+			)
+			.then((response) => {
+				alert("카테고리가 추가되었습니다.");
+				fetchData();
+			})
+			.catch((error) => {
+				console.error("에러", error);
+			});
 	};
 	const clickHandler = (event: React.MouseEvent<HTMLElement>): void => {
 		event.currentTarget.parentElement!.parentElement!.classList.toggle("fold");
@@ -51,8 +83,15 @@ function AdminBoardItem({ board, categories, index, editData }: any) {
 	};
 	//삭제
 	const handleBoardDelete = () => {
-		board["isDeleted"] = true;
-		setIsDelete(true);
+		const isBoardDelete = window.confirm(
+			"게시판 안의 모든 카테고리와 게시글이 삭제됩니다. 그래도 진행하시겠습니까?"
+		);
+		if (isBoardDelete) {
+			board["isDeleted"] = true;
+			setIsDelete(true);
+		} else {
+			alert("게시판 삭제를 취소했습니다.");
+		}
 	};
 	return (
 		<Draggable draggableId={`board-${board.id}`} index={index}>

--- a/client/src/components/AdminCategoryItem.tsx
+++ b/client/src/components/AdminCategoryItem.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 
 function AdminCategoryItem({ category, index, board, editData }: any) {
 	const [isEdit, setIsEdit] = useState(false);
-	const [categoryName, setCategoryName] = useState(category.categoryName);
+	const [categoryName, setCategoryName] = useState(category.name);
 	const [isDelete, setIsDelete] = useState(
 		"isDeleted" in category ? category["isDeleted"] : false
 	);
@@ -22,6 +22,16 @@ function AdminCategoryItem({ category, index, board, editData }: any) {
 	const handleCategoryDelete = () => {
 		category["isDeleted"] = true;
 		setIsDelete(true);
+
+		const isCategoryDelete = window.confirm(
+			"카테고리 안의 게시글이 모두 삭제됩니다. 그래도 진행하시겠습니까?"
+		);
+		if (isCategoryDelete) {
+			category["isDeleted"] = true;
+			setIsDelete(true);
+		} else {
+			alert("카테고리 삭제를 취소했습니다.");
+		}
 	};
 	return (
 		<Draggable draggableId={`category-${category.id}`} index={index}>
@@ -52,7 +62,7 @@ function AdminCategoryItem({ category, index, board, editData }: any) {
 								inputValue={categoryName}
 							/>
 						) : (
-							category.categoryName
+							category.name
 						)}
 					</div>
 					{isEdit ? (

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -5,7 +5,6 @@ const Home = () => {
 	return (
 		<div>
 			<h3>HOME</h3>
-			<Admin />
 		</div>
 	);
 };

--- a/client/src/pages/UserPage.tsx
+++ b/client/src/pages/UserPage.tsx
@@ -54,13 +54,7 @@ const UserPage: React.FC<userPageProps> = ({ userData }) => {
 				</div>
 				<div className="user_button_wrap">
 					<a href={`/user/${userData?.id}/edit`}>사용자 정보 수정</a>
-					{userData?.isAdmin ? (
-						<Button
-							buttonType="another"
-							buttonSize="big"
-							buttonLabel="관리자 페이지"
-						/>
-					) : null}
+					{userData?.isAdmin ? <a href={`./admin`}>관리자 페이지</a> : null}
 				</div>
 			</div>
 			<div className="user_written_wrap">


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 관리자 페이지 게시판 및 카테고리 수정 API 연결
- 게시판 생성 API 연결
- 카테고리 생성 API 연결
- 게시판, 카테고리 삭제시 시스템 확인창 추가

# 느낀 점 및 어려운 점
사용자가 게시판을 생성했을 때 서버로부터 성공했다는 응답을 받아오면 게시판 목록을 어떻게 해야할지 고민이었습니다.
예전 작업할 때는 새로고침이 일어나지 않도록 일단 클라이언트 단에서만 변경이 일어나도록 작업했었습니다.
이번에는 게시판 목록을 서버로 요청하여 데이터 상태에 저장하는 부분을 따로 함수로 분리하고,
이 함수를 아래와 같은 상황에서 실행하도록 작업하였습니다.
````
- 컴포넌트가 처음 마운트될 때(빈 종속성 배열을 가진 useEffect),
- 게시글 생성 요청을 성공했을 때
```
함수 내부에 상태가 변경되는 코드가 있기 때문에 해당 함수를 실행하면 자동으로 컴포넌트가 리렌더링되고, 
그러면 자동으로 컴포넌트가 마운트되면서 서버에 저장된 새로운 데이터로 게시판 목록을 받아오게 됩니다.

# [option] 관련 알림사항
프론트에서 필수적인 기능들은 1차적으로 작업을 완료하였습니다.
이후 백엔드 측에서 API가 전면 수정될 예정이기 때문에 1~2주 정도 휴식기를 가지고 변경된 API사항을 반영하려고 합니다. 
