### PR TITLE
[feat/commentCRUD] 댓글 기능 추가

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -893,11 +893,17 @@ input.error {
 .board_content .task-list-item.checked ::before {
 	background: url("./assets/icon_checked_box.svg") no-repeat;
 }
-/* 게시글 상세보기 스타일: 끝 */
+/* 게시글 상세보기 - 댓글 */
+/* 댓글 작성 */
 .comment_write {
 	padding: 32px;
 	border: 1px solid var(--border-color);
 	border-radius: var(--br-md);
+}
+.comment_write_title {
+	line-height: var(--fs-h5);
+	font-size: var(--fs-h5);
+	font-weight: var(--fw-bold);
 }
 .comment_write textarea {
 	width: 100%;
@@ -907,12 +913,149 @@ input.error {
 	border: 1px solid var(--border-color);
 	border-radius: var(--br-md);
 	background: var(--background-color);
+	resize: none;
 }
 .comment_write button {
 	display: block;
 	width: 160px;
 	margin-left: auto;
 }
+/* 댓글 목록 */
+.comments_list_wrap {
+	padding: 32px 0;
+	margin-top: 48px;
+	border-top: 1px solid var(--border-color);
+}
+.comments_title {
+	margin-bottom: 32px;
+	line-height: var(--fs-h5);
+	font-size: var(--fs-h5);
+	font-weight: var(--fw-bold);
+}
+.comment_list_item {
+	padding: 16px 0 0 0;
+	border-bottom: 1px solid var(--border-color);
+}
+.comment_head {
+	display: flex;
+	align-items: center;
+	margin-bottom: 12px;
+}
+.comment_user_profile {
+	display: flex;
+	align-items: center;
+}
+.comment_user_profile .user_img_wrap {
+	width: 28px;
+	height: 28px;
+	border-radius: 100%;
+	background: var(--primary-container-color);
+	overflow: hidden;
+	margin-right: 8px;
+}
+.comment_user_profile .user_name {
+	font-size: var(--fs-normal);
+	font-weight: var(--fw-normal);
+	color: var(--black);
+	margin-right: 8px;
+}
+.comment_user_profile .comment_ceated_time {
+	color: var(--on-background-secondary-color);
+}
+.comment_likes {
+	margin-left: auto;
+	height: 20px;
+	padding: 0 8px 0 26px;
+	border-radius: 20px;
+	border: 1px solid var(--border-color);
+	background: url("./assets/icon_thumb_up.svg") no-repeat;
+	background-position: 8px center;
+}
+.comment_content {
+	margin-bottom: 12px;
+}
+.comment_content_textarea {
+	width: 100%;
+	padding: 12px 16px;
+	margin-bottom: 12px;
+	border: 1px solid var(--border-color);
+	background-color: var(--background-color);
+	border-radius: var(--br-sm);
+	resize: none;
+}
+.comment_update_btn_wrap {
+	display: flex;
+	align-items: center;
+	margin-bottom: 12px;
+}
+.comment_btn {
+	padding: 6px 8px;
+	margin-right: 8px;
+	border-radius: var(--br-md);
+	border: 1px solid var(--primary-color);
+	background-color: var(--white);
+	color: var(--primary-color);
+	font-size: var(--fs-caption);
+	line-height: 1;
+}
+.comment_reply_btns_wrap {
+	padding-bottom: 16px;
+}
+.comment_reply_btn {
+	margin-right: 16px;
+	font-size: var(--fs-caption);
+	font-weight: var(--fs-caption);
+	color: var(--on-background-color);
+}
+.comment_reply_btn.create_comment_child:hover {
+	color: var(--primary-color);
+}
+.comment_reply_btn.toggle_view_child_comments {
+	color: var(--primary-color);
+}
+.comment_children_wrap {
+	padding: 0 36px 16px 36px;
+	background-color: var(--background-color);
+	border-top: 1px solid var(--border-color);
+}
+.comment_children_btn_wrap {
+	padding: 24px 0;
+}
+.comment_children_btn_wrap button.another {
+	padding: 0;
+	width: 100%;
+	height: 48px;
+	border: 1px solid var(--on-background-color);
+}
+.reply_create_wrap {
+	width: 100%;
+}
+.reply_create_wrap textarea {
+	width: 100%;
+	padding: 8px;
+	background: var(--white);
+	border: 1px solid var(--border-color);
+	border-radius: var(--br-md);
+	color: var(--on-background-color);
+	resize: none;
+}
+.reply_create_btns {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	margin-top: 12px;
+}
+.reply_create_btn {
+	margin-left: 8px;
+	padding: 6px 8px;
+	border: 1px solid var(--primary-color);
+	border-radius: var(--br-md);
+	background: var(--white);
+	color: var(--primary-color);
+	line-height: 1;
+	font-size: var(--fs-caption);
+}
+
 /* board write */
 .board_write_box {
 	padding: 48px;

--- a/client/src/components/BoardComment.tsx
+++ b/client/src/components/BoardComment.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect } from "react";
+import Button from "../components/Button";
+import CommentListItem from "./CommentListItem";
+import axios from "axios";
+import { getAccessToken } from "../assets/tokenActions";
+import dummyCommentsData from "./../data/boardCommentsData.json";
+
+const BoardComment = ({
+	postId,
+	memberId,
+}: {
+	postId: string | number;
+	memberId: string | number;
+}) => {
+	const api = process.env.REACT_APP_API_URL;
+	const [comment, setComment] = useState<string>("");
+	const [commentList, setCommentList] = useState<any>();
+
+	const fetchCommentData = () => {
+		const accessToken = getAccessToken();
+		if (accessToken) {
+			axios
+				.get(`${api}/api/v1/comment?post=${postId}`, {
+					headers: { Authorization: accessToken },
+				})
+				.then((res) => {
+					// console.log(res.data.data); 성공적으로 삭제해도 isRemoved 떠서 확인필요
+					setCommentList(res.data.data);
+				})
+				.catch((_) => {});
+		}
+	};
+
+	useEffect(() => {
+		//댓글목록 Read
+		fetchCommentData();
+	}, []);
+
+	const handleChangeComment = (event: any) => {
+		setComment(event.target.value);
+	};
+	const handleClickCommentSubmit = () => {
+		const accessToken = getAccessToken();
+		//댓글 Create
+		if (accessToken) {
+			axios
+				.post(
+					`${api}/api/v1/comment/create`,
+					{
+						text: comment,
+						postId: postId,
+					},
+					{
+						headers: { Authorization: accessToken },
+					}
+				)
+				.then((res) => {
+					alert("댓글이 등록되었습니다.");
+					setComment("");
+					fetchCommentData();
+				})
+				.catch((_) => {
+					alert("댓글 등록에 실패했습니다.");
+				});
+		}
+	};
+
+	return (
+		<div className="board_comment">
+			<div className="comment_write">
+				<dl>
+					<dt className="comment_write_title">댓글 작성</dt>
+					<dd>
+						<textarea
+							placeholder="댓글을 작성하세요"
+							onChange={(e) => handleChangeComment(e)}
+							value={comment}
+						></textarea>
+					</dd>
+				</dl>
+				<Button
+					buttonType="primary"
+					buttonSize="big"
+					buttonLabel="댓글 입력"
+					onClick={handleClickCommentSubmit}
+				/>
+			</div>
+			{commentList ? (
+				<div className="comments_list_wrap">
+					<h4 className="comments_title">댓글 목록</h4>
+					<ul className="comment_list">
+						{/* 기본  */}
+						{commentList?.map((el: any, idx: number) => {
+							return (
+								<li className="comment_list_item" key={idx}>
+									<CommentListItem
+										data={el}
+										isChild={false}
+										postId={postId}
+										memberId={memberId}
+										fetchData={fetchCommentData}
+									/>
+									{el.children.length > 0 ? (
+										<div className="comment_children_wrap">
+											<ul className="comment_children_list">
+												{el.children.map((child: any, childIdx: number) => (
+													<li className="comment_list_item">
+														<CommentListItem
+															data={child}
+															isChild={true}
+															postId={postId}
+															memberId={memberId}
+															fetchData={fetchCommentData}
+														/>
+													</li>
+												))}
+											</ul>
+										</div>
+									) : null}
+								</li>
+							);
+						})}
+
+						{/* 답글 있을 때: 접혔을 때  */}
+						{/* 답글 있을 때: 펼쳤을 때  */}
+						{/* 내가 쓴 글인 경우 */}
+						{/* 내가 쓴 글인 경우: 수정할 때  */}
+						{/* 대댓글 기본  */}
+						{/* 대댓글 기본: 내가 쓴 경우 */}
+						{/* 대댓글 기본: 내가 쓴 경우: 수정할 때 */}
+					</ul>
+				</div>
+			) : null}
+		</div>
+	);
+};
+export default BoardComment;

--- a/client/src/components/CommentListItem.tsx
+++ b/client/src/components/CommentListItem.tsx
@@ -1,0 +1,225 @@
+import { useState } from "react";
+import { getAccessToken } from "../assets/tokenActions";
+import axios from "axios";
+
+interface CommentListItemType {
+	id: number;
+	text: string;
+	voteCount: number;
+	voteStatus: boolean;
+	memberId: number;
+	memberName: string;
+	createdAt: string;
+	isRemoved?: boolean;
+	children?: any[];
+	parentId?: number;
+}
+
+const CommentListItem = ({
+	data,
+	isChild,
+	postId,
+	memberId,
+	fetchData,
+}: {
+	data: CommentListItemType;
+	isChild: boolean;
+	postId: string | number;
+	memberId: string | number;
+	fetchData: any;
+}) => {
+	const api = process.env.REACT_APP_API_URL;
+	const [isUpdating, setIsUpdating] = useState<boolean>(false);
+	const [comment, setComment] = useState<string>(data.text);
+	const [isReplyWriting, setIsReplyWriting] = useState<boolean>(false);
+	const [reply, setReply] = useState<string>("");
+
+	const handleClickCommentUpdate = () => {
+		setIsUpdating(true);
+	};
+	const handleChangeComment = (event: any) => {
+		setComment(event.target.value);
+	};
+	const handleClickCommentUpdateComplete = () => {
+		//댓글 Update
+		const accessToken = getAccessToken();
+		if (accessToken) {
+			axios
+				.patch(
+					`${api}/api/v1/comment/update/${data.id}`,
+					{ text: comment },
+					{
+						headers: { Authorization: accessToken },
+					}
+				)
+				.then((res) => {
+					alert("댓글이 수정되었습니다.");
+					fetchData();
+				})
+				.catch((_) => {
+					alert("댓글 수정에 실패했습니다.");
+				});
+		}
+		setIsUpdating(false);
+	};
+	const handleClickCommentDelete = () => {
+		//댓글 delete
+		//팝업창으로 대체할 것
+		let isDeleteYes = window.confirm("댓글을 삭제하시겠습니까?");
+		if (isDeleteYes) {
+			const accessToken = getAccessToken();
+			if (accessToken) {
+				axios
+					.get(`${api}/api/v1/comment/${data.id}`, {
+						headers: { Authorization: accessToken },
+					})
+					.then((res) => {
+						alert("댓글이 삭제되었습니다.");
+						fetchData();
+					})
+					.catch((_) => {
+						alert("댓글 삭제 오류가 발생했습니다.");
+					});
+			}
+		}
+	};
+	const handleClicktoggleReply = () => {
+		setIsReplyWriting((prev) => !prev);
+	};
+	const handleChangeReply = (event: any) => {
+		setReply(event.target.value);
+	};
+	const handleClickReplySubmit = () => {
+		const accessToken = getAccessToken();
+		//답글 Create
+		if (accessToken) {
+			axios
+				.post(
+					`${api}/api/v1/comment/create`,
+					{
+						text: reply,
+						postId: postId,
+						parentCommentId: data.id,
+					},
+					{
+						headers: { Authorization: accessToken },
+					}
+				)
+				.then((res) => {
+					alert("답글이 등록되었습니다.");
+					setReply("");
+					setIsReplyWriting(false);
+					fetchData();
+				})
+				.catch((_) => {
+					alert("답글 등록에 실패했습니다.");
+				});
+		}
+	};
+
+	return (
+		<>
+			{data.isRemoved ? (
+				<div>삭제된 댓글입니다.</div>
+			) : (
+				<>
+					<div className="comment_head">
+						<div className="comment_user_profile">
+							<div className="user_img_wrap"></div>
+							<h5 className="user_name">{data.memberName}</h5>
+							<div className="comment_ceated_time">{data.createdAt}</div>
+						</div>
+						<div className="comment_likes">{data.voteCount}</div>
+					</div>
+					{isUpdating ? (
+						<div className="comment_body">
+							<textarea
+								className="comment_content_textarea"
+								onChange={(e) => handleChangeComment(e)}
+							>
+								{comment}
+							</textarea>
+							<div className="comment_update_btn_wrap">
+								<button
+									className="comment_btn update"
+									onClick={handleClickCommentUpdateComplete}
+								>
+									수정완료
+								</button>
+								<button
+									className="comment_btn delete"
+									onClick={handleClickCommentDelete}
+								>
+									삭제
+								</button>
+							</div>
+						</div>
+					) : (
+						<div className="comment_body">
+							<div className="comment_content">{comment}</div>
+							{memberId === data.memberId ? (
+								<div className="comment_update_btn_wrap">
+									<button
+										className="comment_btn update"
+										onClick={handleClickCommentUpdate}
+									>
+										수정
+									</button>
+									<button
+										className="comment_btn delete"
+										onClick={handleClickCommentDelete}
+									>
+										삭제
+									</button>
+								</div>
+							) : null}
+						</div>
+					)}
+					{isChild ? null : (
+						<div className="comment_reply_btns_wrap">
+							{/* {data.children!.length > 0 ? (
+								<button className="comment_reply_btn toggle_view_child_comments show">
+									답글 더보기
+								</button>
+							) : null} */}
+							{isReplyWriting ? (
+								<div className="reply_create_wrap">
+									<div>
+										<textarea
+											placeholder="답글을 작성하세요"
+											onChange={(e) => handleChangeReply(e)}
+											value={reply}
+										></textarea>
+									</div>
+									<div className="reply_create_btns">
+										<button
+											className="reply_create_btn reply_cancel"
+											onClick={handleClicktoggleReply}
+										>
+											취소
+										</button>
+										<button
+											className="reply_create_btn reply_submit"
+											onClick={handleClickReplySubmit}
+										>
+											작성 완료
+										</button>
+									</div>
+								</div>
+							) : (
+								<button
+									className="comment_reply_btn create_comment_child"
+									onClick={handleClicktoggleReply}
+								>
+									답글
+								</button>
+							)}
+						</div>
+					)}
+				</>
+			)}
+		</>
+	);
+};
+
+export default CommentListItem;

--- a/client/src/data/boardCommentsData.json
+++ b/client/src/data/boardCommentsData.json
@@ -1,0 +1,92 @@
+[
+	{
+		"id": 1,
+		"text": "댓글 테스트1",
+		"voteCount": 1,
+		"voteStatus": true,
+		"isRemoved": true,
+		"memberId": 1,
+		"memberName": "운영자수정",
+		"createdAt": "2024-03-24 03:12",
+		"children": [
+			{
+				"id": 2,
+				"text": "댓글 테스트1",
+				"voteCount": 0,
+				"voteStatus": false,
+				"memberId": 1,
+				"memberName": "운영자수정",
+				"parentId": 1,
+				"createdAt": "2024-03-24 03:13",
+				"removed": false
+			},
+			{
+				"id": 3,
+				"text": "댓글 테스트2",
+				"voteCount": 0,
+				"voteStatus": false,
+				"memberId": 1,
+				"memberName": "운영자수정",
+				"parentId": 1,
+				"createdAt": "2024-03-24 03:15",
+				"removed": false
+			},
+			{
+				"id": 4,
+				"text": "댓글 테스트3",
+				"voteCount": 0,
+				"voteStatus": false,
+				"memberId": 1,
+				"memberName": "운영자수정",
+				"parentId": 1,
+				"createdAt": "2024-03-24 03:15",
+				"removed": false
+			}
+		]
+	},
+	{
+		"id": 5,
+		"text": "댓글 테스트2",
+		"voteCount": 0,
+		"voteStatus": false,
+		"isRemoved": false,
+		"memberId": 1,
+		"memberName": "운영자수정",
+		"createdAt": "2024-03-24 03:36",
+		"children": [
+			{
+				"id": 6,
+				"text": "댓글 테스트 하위 1",
+				"voteCount": 0,
+				"voteStatus": false,
+				"memberId": 1,
+				"memberName": "운영자수정",
+				"parentId": 5,
+				"createdAt": "2024-03-24 03:37",
+				"removed": false
+			},
+			{
+				"id": 7,
+				"text": "댓글 테스트 하위 2",
+				"voteCount": 0,
+				"voteStatus": false,
+				"memberId": 1,
+				"memberName": "운영자수정",
+				"parentId": 5,
+				"createdAt": "2024-03-24 03:37",
+				"removed": false
+			},
+			{
+				"id": 8,
+				"text": "댓글 테스트 하위 3",
+				"voteCount": 0,
+				"voteStatus": false,
+				"memberId": 1,
+				"memberName": "운영자수정",
+				"parentId": 5,
+				"createdAt": "2024-03-24 03:37",
+				"removed": false
+			}
+		]
+	}
+]

--- a/client/src/pages/BoardDetail.tsx
+++ b/client/src/pages/BoardDetail.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import Button from "../components/Button";
 import axios from "axios";
 import { getAccessToken } from "../assets/tokenActions";
+import BoardComment from "../components/BoardComment";
 
 interface BoardDetailData {
 	postId: number;
@@ -76,7 +76,6 @@ const BoardDetail = () => {
 				"게시글을 불러오지 못했습니다."
 			) : (
 				<>
-					{" "}
 					<div className="board_header">
 						<p className="board_date">{postData.createdAt}</p>
 						<h4 className="board_detail_title">{postData.title}</h4>
@@ -116,31 +115,7 @@ const BoardDetail = () => {
 						className="board_content"
 						dangerouslySetInnerHTML={{ __html: postData.content }}
 					></div>
-					<div className="board_comment">
-						<div className="comment_write">
-							<dl>
-								<dt className="title_h4">댓글 작성</dt>
-								<dd>
-									<textarea placeholder="댓글을 작성하세요"></textarea>
-								</dd>
-							</dl>
-							<Button
-								buttonType="primary"
-								buttonSize="big"
-								buttonLabel="댓글 입력"
-							/>
-						</div>
-						<div className="comment_list">
-							{/* 기본  */}
-							{/* 답글 있을 때: 접혔을 때  */}
-							{/* 답글 있을 때: 펼쳤을 때  */}
-							{/* 내가 쓴 글인 경우 */}
-							{/* 내가 쓴 글인 경우: 수정할 때  */}
-							{/* 대댓글 기본  */}
-							{/* 대댓글 기본: 내가 쓴 경우 */}
-							{/* 대댓글 기본: 내가 쓴 경우: 수정할 때 */}
-						</div>
-					</div>
+					<BoardComment postId={params.postId!} memberId={myMemberId!} />
 				</>
 			)}
 		</div>


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 댓글 영역 퍼블리싱
- 댓글 CRUD 추가
- 대댓글 기능 추가

# 느낀 점 및 어려운 점
## 어려운 점
크게 어려운 점은 없었습니다. 다만 챙길 내용이 많아 좀 복잡했습니다.
## 느낀 점
- 예전에 CRUD를 만들 때는 댓글 등의 컨텐츠를 생성, 수정, 삭제한 뒤 상태만 변화시키고 데이터를 리로드시키는 것은 하지 않았었습니다.
그러나 이번에는 댓글 목록을 불러오는 fetch함수를 따로 분리하여 생성, 수정, 삭제 후 목록을 갱신하는 용도로 사용하는 방법을 알아내 적용해 보았습니다.
- 댓글에 대댓글 까지 중복되는 부분이 있어서 코드를 최대한 재사용하고자 디자인을 수정하였습니다. 댓글, 대댓글에 대한 UI는 그 예시가 다양하기 때문에 여러 사이트들을 참고해서 수정하고 퍼블리싱 하였습니다.
- 댓글을 접기, 펼치기 기능은 원래 도입하려하였으나 없어도 괜찮을 것 같아 일단 추후 댓글이 길어지면 접기, 펼치기를 추가할 예정입니다. 

# [option] 관련 알림사항
- 1수준의 댓글이 삭제되면 "삭제된 댓글입니다"로 뜨도록 작업했으나 서버에서 데이터를 확인해보면 isRemoved값이 여전히 false인 것을 확인할 수 있습니다. 추후 댓글과 관련하여 수정사항이 생기면 반영할 예정이고, 일단은 다른 작업을 할 예정입니다.
