### PR TITLE
[feat/googleLogin] 구글 로그인 기능 추가

### DIFF
--- a/client/src/assets/tokenActions.ts
+++ b/client/src/assets/tokenActions.ts
@@ -3,6 +3,11 @@ export const isAccessToken = () => {
 	return !!token;
 };
 export const getAccessToken = () => {
+	if (document.cookie !== "") {
+		const cookie_list = document.cookie.split(";");
+		const cookieAccessToken = cookie_list[0].split("token=")[1];
+		saveAccessToken(`Bearer ${cookieAccessToken}`);
+	}
 	return localStorage.getItem("accessToken");
 };
 export const saveAccessToken = (token: string) => {

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -28,7 +28,7 @@ const Header = (props: HeaderProps) => {
 		let token = getAccessToken();
 		if (token) {
 			axios
-				.get(`${api}/api/v1/member/single-info`, {
+				.get(`${api}/api/v1/member/profile`, {
 					headers: { Authorization: token },
 				})
 				.then((res) => {

--- a/client/src/pages/BoardDetail.tsx
+++ b/client/src/pages/BoardDetail.tsx
@@ -38,7 +38,7 @@ const BoardDetail = () => {
 
 		if (accessToken) {
 			axios
-				.get(`${api}/api/v1/member/single-info`, {
+				.get(`${api}/api/v1/member/profile`, {
 					headers: { Authorization: accessToken },
 				})
 				.then((res) => {

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Dispatch, SetStateAction } from "react";
+import React, { useState, Dispatch, useEffect } from "react";
 import Input from "./../components/Input";
 import Button from "./../components/Button";
 import { validator, ValidatorStatus } from "../assets/validater";
@@ -13,6 +13,7 @@ interface Props {
 const Login = (props: Props) => {
 	const api = process.env.REACT_APP_API_URL;
 	const navigate = useNavigate();
+	const googleLoginURI = process.env.REACT_APP_GOOGLE_LOGIN_URI;
 	const [form, setForm] = useState({
 		email: "",
 		password: "",
@@ -33,6 +34,7 @@ const Login = (props: Props) => {
 			password: value,
 		}));
 	};
+
 	//유효성 검사
 	const validatorStatusEmail: ValidatorStatus = {
 		value: form.email,
@@ -54,7 +56,6 @@ const Login = (props: Props) => {
 		axios
 			.post(`${api}/api/v1/login`, form, { withCredentials: true })
 			.then((response) => {
-				console.log(response.headers.authorization);
 				saveAccessToken(response.headers.authorization);
 				props.setIsLogin(true);
 				navigate("/");
@@ -103,7 +104,9 @@ const Login = (props: Props) => {
 				<div className="sns_login_btns">
 					<button className="sns_btn kakao">카카오 로그인</button>
 					<button className="sns_btn naver">네이버 로그인</button>
-					<button className="sns_btn google">구글 로그인</button>
+					<a className="sns_btn google" href={googleLoginURI}>
+						구글 로그인
+					</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 구글 로그인 기능 추가
- 관련 환경변수 추가
- 구글 로그인 후 쿠키 조회하여 엑세스 토큰 저장하는 기능 추가

# 느낀 점 및 어려운 점
## 느낀 점
- 소셜 로그인, 구글 로그인, 쿠키 등을 다루는 작업에 대해 두루 알기 전에는 조금 막막하기도 했지만 막상 검색해보고 학습하고 나서는 잘 적용할 수 있었습니다. 테스트 후에 잘 되는 것을 확인하니 기분이 정말 좋았어요.
## 어려운 점
- 구글 로그인을 구현하기 위해서는 클라이언트 뿐만 아니라 서버를 포함해 전체 과정에 대한 이해가 있어야 합니다. 그리고 서버, 클라이언트 모두 어떤 방식을 택하느냐에 따라 방법이 달라지기에 서버 측과 충분한 대화가 필요했습니다. 다음은 이번 작업에서 구현했던 구글 로그인 과정입니다.
- 구글 로그인 구현 과정
1. 구글 로그인을 구현하기 위해 먼저 구글에 사이트 정보 등을 입력해야 합니다.
2. 구글 로그인을 시도하기 위한 URI가 주어집니다. 클라이언트 측에서는 로그인을 위해 이 URI로 이동해야 합니다.
3. 구글에서 로그인 처리가 완료되면 서버 측에서는 처리 후 리다이렉트 시켜줄 클라이언트 사이트 URL이 필요합니다. 서버는 이 리다이렉트 페이지로 클라이언트 페이지를 리다이렉트 시켜줍니다.
4. 리다이렉트된 클라이언트 페이지로 서버가 쿠키를 보내줍니다.
5. 클라이언트에서는 쿠키를 조회하여 엑세스 토큰을 저장합니다. 그리고 이것으로 로그인 처리를 합니다.

# [option] 관련 알림사항
- 이 다음은 게시글 이미지 처리를 개선하는 작업을 하려고 합니다.
