### PR TITLE
[fix/editor] 게시글 관련 API 수정 반영, 이미지 전송 관련 변경사항(base64 -> S3 url로 출처 변경) 반영

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,8 +24,8 @@ export interface userDataType {
 	nickname: string;
 	profileImage: string | null;
 	score: number;
-	isAdmin: boolean;
-	timeInfo: string;
+	role: string;
+	timeInfo?: string;
 }
 
 function App() {

--- a/client/src/assets/tokenActions.ts
+++ b/client/src/assets/tokenActions.ts
@@ -14,5 +14,8 @@ export const saveAccessToken = (token: string) => {
 	localStorage.setItem("accessToken", token);
 };
 export const removeAccessToken = () => {
+	if (document.cookie !== "") {
+		document.cookie = "cookiename= ; expires = Thu, 01 Jan 1970 00:00:00 GMT";
+	}
 	localStorage.removeItem("accessToken");
 };

--- a/client/src/components/BoardComment.tsx
+++ b/client/src/components/BoardComment.tsx
@@ -20,7 +20,7 @@ const BoardComment = ({
 		const accessToken = getAccessToken();
 		if (accessToken) {
 			axios
-				.get(`${api}/api/v1/comment?post=${postId}`, {
+				.get(`${api}/api/v1/comment?postId=${postId}`, {
 					headers: { Authorization: accessToken },
 				})
 				.then((res) => {

--- a/client/src/components/Boarditem.tsx
+++ b/client/src/components/Boarditem.tsx
@@ -14,10 +14,11 @@
 // 	timeInfo: string;
 // }
 
+import { useEffect } from "react";
+
 //서버 응답 기준
 interface BoardItemData {
 	postId?: number;
-	id?: number;
 	boardId: number;
 	boardName: string;
 	categoryId?: number;
@@ -35,7 +36,7 @@ const BoardItem = ({ data }: { data: BoardItemData }) => {
 	return (
 		<div className="board_item">
 			<a
-				href={`/board/${data.boardId}-${data.boardName}/${data.id}`}
+				href={`/board/${data.boardId}-${data.boardName}/${data.postId}`}
 				title={data.title}
 			>
 				<div className="board_item_element_wrap">

--- a/client/src/components/EditorUnit.tsx
+++ b/client/src/components/EditorUnit.tsx
@@ -1,12 +1,16 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useRef } from "react";
 import { Editor } from "@toast-ui/react-editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
 import "@toast-ui/editor/dist/i18n/ko-kr";
 import Button from "./Button";
+import axios from "axios";
 
-const EditorUnit = React.forwardRef((props, ref) => {
+type HookCallback = (url: string, text?: string) => void;
+
+const EditorUnit = React.forwardRef((props: any, ref) => {
 	const editorRef = useRef<Editor>(null);
+	const latestBoardDataRef = useRef(props.nowBoardData); // 최신 상태를 저장할 ref
 
 	//Editor의 내용을 가져오는 함수
 	const getInstance = () => {
@@ -16,6 +20,24 @@ const EditorUnit = React.forwardRef((props, ref) => {
 	React.useImperativeHandle(ref, () => ({
 		getInstance,
 	}));
+
+	const handleImageUpload = (blob: Blob | any, callback: HookCallback) => {
+		//실행되는 시점: 이미지를 업로드하고 '확인'버튼을 클릭했을 때.
+		//callback이 실행되지 않으면 이미지 업로드 창이 닫히지 않는다.
+		//callback(`${blob.name}`, `${blob.name}`); //이미지 저장된 url, img 대체 텍스트
+		//callback사용용도: 이미지를 먼저 서버에 업로드하여 응답으로 오는 url이나 파일명을 html에 처리한다.
+
+		//blob데이터 저장
+		props.setBlobData(blob);
+
+		//일단 이미지 그대로 두기
+		const reader = new FileReader();
+		reader.readAsDataURL(blob);
+		reader.onloadend = () => {
+			const base64data = reader.result;
+			callback(`${base64data}`, `${blob.name}`); //이미지 저장된 url, img 대체 텍스트
+		};
+	};
 
 	return (
 		<div className="editor_unit">
@@ -27,6 +49,9 @@ const EditorUnit = React.forwardRef((props, ref) => {
 				initialEditType="wysiwyg"
 				useCommandShortcut={true}
 				ref={editorRef}
+				hooks={{
+					addImageBlobHook: handleImageUpload,
+				}}
 			/>
 		</div>
 	);

--- a/client/src/pages/BoardDetail.tsx
+++ b/client/src/pages/BoardDetail.tsx
@@ -58,7 +58,7 @@ const BoardDetail = () => {
 		if (isDeleteYes) {
 			console.log(params.postId);
 			axios
-				.delete(`${api}/api/v1/post/${params.postId}`, {
+				.delete(`${api}/api/v1/post/delete/${params.postId}`, {
 					headers: { Authorization: accessToken },
 				})
 				.then((res) => {
@@ -77,14 +77,14 @@ const BoardDetail = () => {
 			) : (
 				<>
 					<div className="board_header">
-						<p className="board_date">{postData.createdAt}</p>
-						<h4 className="board_detail_title">{postData.title}</h4>
 						<div className="board_detail_info">
 							<p className="board_info">{params.boardInfo?.split("-")[1]}</p>
 							{postData!.categoryId ? (
 								<p className="board_info">{postData!.categoryId}</p>
 							) : null}
+							<p className="board_date">{postData.createdAt}</p>
 						</div>
+						<h4 className="board_detail_title">{postData.title}</h4>
 						<div className="board_detail_info">
 							<div className="writer_profile">
 								<div className="profile_img_wrap"></div>

--- a/client/src/pages/BoardWrite.tsx
+++ b/client/src/pages/BoardWrite.tsx
@@ -12,7 +12,7 @@ import { getAccessToken } from "../assets/tokenActions";
 interface FormType {
 	title: string;
 	content: string;
-	boardId: string;
+	boardId: string | number;
 	// [key: string]: string; // 인덱스 시그니처 추가
 }
 
@@ -38,11 +38,11 @@ const BoardWrite = () => {
 		// }
 		//관리자 여부 판별
 		axios
-			.get(`${api}/api/v1/member/single-info`, {
+			.get(`${api}/api/v1/member/profile`, {
 				headers: { Authorization: accessToken },
 			})
 			.then((response) => {
-				if (response.data.data.isAdmin) setIsAdmin(true);
+				if (response.data.data.role === "ADMIN") setIsAdmin(true);
 			})
 			.catch((_) => {});
 		//게시판 정보 불러오기
@@ -59,16 +59,19 @@ const BoardWrite = () => {
 	const [nowBoardData, setNowBoardData] = useState<BoardDataType>(); //현재 선택된 게시판 정보
 	const [nowCategoryId, setNowCategoryId] = useState(0); //현재 선택된 카테고리 id
 	const [selectValueCategory, setSelectValueCategory] = useState(""); //현재 선택된 카테고리
-	const [titleValue, setTitleValue] = useState("");
+	const [titleValue, setTitleValue] = useState(""); //제목
+	const [filesFormData, setFilesFormData] = useState<FormData>(new FormData()); //이미지파일
 
 	const editorRef = useRef<any>(null); //작성된 내용
-	//게시판 선택
+
+	//함수 - 게시판 선택
 	const handleSelectboard = (board: string) => {
 		const matchedBoard = data.filter((el: any) => el.name === board)[0];
 		setNowBoardData(matchedBoard);
 		checkCategory(matchedBoard);
 	};
-	//카테고리 유무 확인
+
+	//함수 - 카테고리 유무 확인
 	const checkCategory = (board: BoardDataType) => {
 		setCategoryItem([]);
 		if (board !== undefined) {
@@ -78,7 +81,8 @@ const BoardWrite = () => {
 			}
 		}
 	};
-	//카테고리 선택
+
+	//함수 - 카테고리 선택
 	const handleSelectCategory = (categoryItem: string) => {
 		const matchedCategory: any = nowBoardData!.category.find(
 			(el: any) => el.name === categoryItem
@@ -90,52 +94,160 @@ const BoardWrite = () => {
 	const cancelClickHandler = () => {
 		navigate(`/board/${nowBoardData!.id}-${nowBoardData!.name}`);
 	};
-	//제출
-	const submitHandler = () => {
+
+	//이미지 관련
+
+	//함수 - 이미지 blob데이터 저장
+	const setBlobData = (blob: Blob) => {
+		const newFormData = new FormData();
+		// 기존 formData의 모든 항목을 newFormData로 복사
+		filesFormData.forEach((value, key) => {
+			newFormData.append(key, value);
+		});
+		newFormData.append("files", blob); // blob 데이터를 추가
+		setFilesFormData(newFormData); // 업데이트된 FormData를 상태에 저장
+	};
+
+	//함수 - 이미지 전송: postId, imgsUrl 리턴
+	const uploadImage = async (formData: FormData, config: any) => {
+		try {
+			const res = await axios.post(
+				`${api}/api/v1/post/create`,
+				formData,
+				config
+			);
+			const postId = res.data.data.id;
+			const filesUrls = res.data.data.files;
+			return [postId, filesUrls];
+		} catch (error) {
+			console.log("이미지 전송 실패", error);
+			return ["", ""];
+		}
+	};
+
+	//함수 - content에서 이미지 데이터 찾아서 변환(base64 -> url)
+	const imgConverter = (content: string, urlArr: string[]): string => {
+		const base64ImageRegex =
+			/<img src="data:image\/(png|jpeg|jpg);base64,[^"]+"[^>]*>/g;
+		const base64Images = content.match(base64ImageRegex) || [];
+
+		// base64 이미지를 URL로 교체
+		let processedContent = content;
+		base64Images.forEach((base64ImageTag, index) => {
+			const imageUrl = urlArr[index];
+			const newImageTag = base64ImageTag.replace(
+				/src="data:image\/(png|jpeg|jpg);base64,[^"]+"/,
+				`src="${imageUrl}"`
+			);
+			processedContent = processedContent.replace(base64ImageTag, newImageTag);
+		});
+
+		return processedContent;
+	};
+
+	//함수 - 게시글 제출
+	const submitHandler = async () => {
+		//게시판 id
 		const id = nowCategoryId
 			? nowCategoryId.toString()
-			: nowBoardData!.id.toString(); //게시판 id
-		const editorData: string = editorRef.current!.getInstance().getHTML(); //작성된 데이터
-		const form: FormType = {
-			title: titleValue,
-			content: editorData,
-			boardId: id,
-		};
-
-		const formData = new FormData();
-		formData.append(
-			"data",
-			new Blob([JSON.stringify(form)], {
-				type: "application/json",
-			})
-		);
+			: nowBoardData!.id.toString();
+		//작성된 데이터
+		const editorData: string = editorRef.current!.getInstance().getHTML();
+		//데이터 전송시 설정값, 토큰
 		const postAxiosConfig = {
 			headers: {
 				"Content-Type": "multipart/form-data", // FormData를 사용할 때 Content-Type을 변경
-				"Authorization": `${localStorage.getItem("accessToken")}`,
+				Authorization: `${getAccessToken()}`,
 			},
 		};
-		axios
-			.post(`${api}/api/v1/post/create`, formData, postAxiosConfig)
-			.then((_) => {
-				navigate(`/board/${nowBoardData!.id}-${nowBoardData!.name}`);
-			})
-			.catch((error) => {
-				alert("게시판 등록을 실패했습니다.");
-				if (error.response) {
-					// 서버 응답이 있을 경우 (에러 상태 코드가 반환된 경우)
-					console.error("서버 응답 에러:", error.response.data);
-					console.error("응답 상태 코드:", error.response.status);
-					console.error("응답 헤더:", error.response.headers);
-				} else if (error.request) {
-					// 요청이 전혀 되지 않았을 경우
-					console.error("요청 에러:", error.request);
-				} else {
-					// 설정에서 문제가 있어 요청이 전송되지 않은 경우
-					console.error("Axios 설정 에러:", error.message);
-				}
-				console.error("에러 구성:", error.config);
+
+		//이미지 없는 경우
+		if (filesFormData.get("files") === null) {
+			const postData = {
+				title: titleValue,
+				content: editorData,
+				boardId: id,
+			};
+			const newFormData: FormData = new FormData();
+			newFormData.append(
+				"data",
+				new Blob([JSON.stringify(postData)], {
+					type: "application/json",
+				})
+			);
+			axios
+				.post(`${api}/api/v1/post/create`, newFormData, postAxiosConfig)
+				.then((_) => {
+					navigate(`/board/${nowBoardData!.id}-${nowBoardData!.name}`);
+				})
+				.catch((error) => {
+					alert("게시판 등록을 실패했습니다.");
+				});
+		} else {
+			//이미지 있는 경우
+			let postData = {
+				title: "images",
+				content: "",
+				boardId: id,
+			};
+			const newFormData: FormData = new FormData();
+			filesFormData.forEach((value, key) => {
+				newFormData.append(key, value);
 			});
+			newFormData.append(
+				"data",
+				new Blob([JSON.stringify(postData)], {
+					type: "application/json",
+				})
+			);
+			//1. 이미지 먼저 전송: postId, imgsUrl값 반환
+			const ImagesReponse = await uploadImage(newFormData, postAxiosConfig);
+			const [postId, filesUrls] = ImagesReponse;
+			if (postId === "" || filesUrls === "") {
+				console.log("이미지 전송 실패");
+				return;
+			}
+			console.log(postId, filesUrls);
+
+			//2. 이미지 src를 base64 -> url로 변경
+			const newContent = imgConverter(editorData, filesUrls);
+
+			//3. 이미지 최종 전송(이미지 등록시 이미 게시글 생성되었으므로 게시글 수정으로 제출)
+			postData.title = titleValue;
+			postData.content = newContent;
+			newFormData.set(
+				"data",
+				new Blob([JSON.stringify(postData)], {
+					type: "application/json",
+				})
+			);
+
+			axios
+				.patch(
+					`${api}/api/v1/post/update/${postId}`,
+					newFormData,
+					postAxiosConfig
+				)
+				.then((_) => {
+					navigate(`/board/${nowBoardData!.id}-${nowBoardData!.name}`);
+				})
+				.catch((error) => {
+					alert("게시판 등록을 실패했습니다.");
+					if (error.response) {
+						// 서버 응답이 있을 경우 (에러 상태 코드가 반환된 경우)
+						console.error("서버 응답 에러:", error.response.data);
+						console.error("응답 상태 코드:", error.response.status);
+						console.error("응답 헤더:", error.response.headers);
+					} else if (error.request) {
+						// 요청이 전혀 되지 않았을 경우
+						console.error("요청 에러:", error.request);
+					} else {
+						// 설정에서 문제가 있어 요청이 전송되지 않은 경우
+						console.error("Axios 설정 에러:", error.message);
+					}
+					console.error("에러 구성:", error.config);
+				});
+		}
 	};
 
 	return (
@@ -178,7 +290,7 @@ const BoardWrite = () => {
 							/>
 						</div>
 					</div>
-					<EditorUnit ref={editorRef} />
+					<EditorUnit ref={editorRef} setBlobData={setBlobData} />
 					<div className="board_editor_button_wrap">
 						<Button
 							buttonType="primary"

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -72,6 +72,7 @@ const Signup = () => {
 			})
 			.catch((error) => {
 				if (error.response) {
+					alert("회원가입에 실패했습니다."); //팝업으로 바꾸기
 					// 서버 응답이 있을 경우 (에러 상태 코드가 반환된 경우)
 					console.error("서버 응답 에러:", error.response.data);
 					console.error("응답 상태 코드:", error.response.status);

--- a/client/src/pages/UserPage.tsx
+++ b/client/src/pages/UserPage.tsx
@@ -14,8 +14,7 @@ import iconUser from "./../assets/icon_user.svg";
 // 	nickname: string;
 // 	profileImage: string | null;
 // 	score: number;
-//  isAdmin: boolean;
-// 	timeInfo: string;
+//  role: string;
 // }
 
 interface userPageProps {
@@ -37,6 +36,7 @@ const UserPage: React.FC<userPageProps> = ({ userData }) => {
 			alert("로그인이 필요한 서비스입니다.");
 			navigate(`/login`);
 		}
+		console.log(userData);
 	}, []);
 
 	return (
@@ -54,7 +54,9 @@ const UserPage: React.FC<userPageProps> = ({ userData }) => {
 				</div>
 				<div className="user_button_wrap">
 					<a href={`/user/${userData?.id}/edit`}>사용자 정보 수정</a>
-					{userData?.isAdmin ? <a href={`/admin`}>관리자 페이지</a> : null}
+					{userData?.role === "ADMIN" ? (
+						<a href={`/admin`}>관리자 페이지</a>
+					) : null}
 				</div>
 			</div>
 			<div className="user_written_wrap">


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [ ]  Feature
- [x]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- API 수정 반영
- 로그아웃시 쿠키 제거 코드 추가
- 기존 이미지 src를 base64에서 S3 url이 되도록 변경

# 느낀 점 및 어려운 점
제일 어려웠던 점은 아무래도 이미지 src 관련이었습니다.
## 1. TOAST UI의 hook의 특성으로 인한 어려움
기존 TOAST UI에서 addImageBlobHook이라는 hook을 제공합니다. 저처럼 이미지 처리를 위해 이미지를 업로드하고 확인 버튼을 클릭하면 업로드된 이미지의 blob데이터를 받을 수 있고, 이미지 src를 지정된 url로 바꿔주는 callback함수를 사용할 수 있습니다. 여기까지는 좀만 학습해도 알아낼 수 있으나 문제는 이 callback함수가 반드시 실행되어야 이미지 업로드 창이 닫히기 때문에 원치않아도 강제로 실행해야 한다는 점이었습니다. 왜냐면 JB API특성상 callback함수가 실행되지 않아야 했기 때문입니다. 
- 해결방법: 
## 2. 서버 API에 맞춘 프로세스 찾기
JB 서버 API는 따로 이미지를 받아 url을 응답으로 보내주는 API가 없습니다. 그리고 지금 상황에서 그런 API만 새로 만들 수는 없어서 결국 현 상황에 맞는 방법을 찾아야 했습니다. 
- 해결 방법: 게시글 작성 완료 버튼을 클릭했을 때 이미지 처리 프로세스를 아래와 같이 수정했습니다.

기존 데이터(제목, 게시글내용, 게시판 아이디) 확보
-> 이미지 업로드시 별도의 formData에 이미지 blob 데이터 저장 후 base64로 이미지 src 내버려둠
(사용자가 이미지를 미리 볼 수 있도록)
-> 이미지만 blob데이터로 포함시켜 게시글 생성 API로 전송
-> 이미지 파일 S3 url을 응답으로 받음
-> 게시글 내용에서 img 태그 src 중 base64로 된 것을 찾아 S3 url로 변경
-> 게시글 수정 API로 최종 전송
## 3. base64, blob, formData에 대한 이해와 처리
base64, blob, formData 등의 개념이 어려웠고, 해결방법은 검색과 학습이었습니다.
이번에 위 개념에 대해 겉핥기로 알고 있어서 좀 더 공부가 필요했습니다.
이미지를 어떻게 전송하지 라는 개념에 직관적으로 떠오르지 않아 이해가 어려웠던 것 같고,
전체 데이터에서 base64를 찾는다는게 좀 애매했는데 정규식을 사용하여 처리할 수 있었습니다.
위 개념들은 앞으로도 사용한다면 다시 한 번 학습하지 않을까 싶습니다. 그러면 좀 더 나아지겠죠?

# [option] 관련 알림사항
이후 카카오 로그인 기능 추가와 몇몇 이슈 해결이 남았습니다. 힘내자 내 자신!!
