### PR TITLE
[fix/nav] 메뉴 데이터 이동, props 연결 추가, 라우팅 변경

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -336,6 +336,89 @@ input.error {
 .login_info_wrap .login_info_btns_name {
 	display: none;
 }
+/* Loading Indicator */
+.loading {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate3d(-50%, -50%, 0);
+	padding: 10px;
+	background: var(--primary-color);
+	-webkit-border-radius: 5px;
+	-moz-border-radius: 5px;
+	border-radius: 5px;
+	z-index: 10;
+}
+.loading-dot {
+	float: left;
+	width: 8px;
+	height: 8px;
+	margin: 0 4px;
+	background: white;
+	-webkit-border-radius: 50%;
+	-moz-border-radius: 50%;
+	border-radius: 50%;
+	opacity: 0;
+	-webkit-animation: loadingFade 1s infinite;
+	-moz-animation: loadingFade 1s infinite;
+	animation: loadingFade 1s infinite;
+}
+.loading-dot:nth-child(1) {
+	-webkit-animation-delay: 0s;
+	-moz-animation-delay: 0s;
+	animation-delay: 0s;
+}
+.loading-dot:nth-child(2) {
+	-webkit-animation-delay: 0.1s;
+	-moz-animation-delay: 0.1s;
+	animation-delay: 0.1s;
+}
+.loading-dot:nth-child(3) {
+	-webkit-animation-delay: 0.2s;
+	-moz-animation-delay: 0.2s;
+	animation-delay: 0.2s;
+}
+.loading-dot:nth-child(4) {
+	-webkit-animation-delay: 0.3s;
+	-moz-animation-delay: 0.3s;
+	animation-delay: 0.3s;
+}
+
+@-webkit-keyframes loadingFade {
+	0% {
+		opacity: 0;
+	}
+	50% {
+		opacity: 0.8;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
+@-moz-keyframes loadingFade {
+	0% {
+		opacity: 0;
+	}
+	50% {
+		opacity: 0.8;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
+@keyframes loadingFade {
+	0% {
+		opacity: 0;
+	}
+	50% {
+		opacity: 0.8;
+	}
+	100% {
+		opacity: 0;
+	}
+}
 
 /* header */
 .header {
@@ -851,6 +934,9 @@ input.error {
 /* 게시글 상세보기 스타일: 시작 */
 .board_content {
 	padding: 48px 0;
+}
+.board_content img {
+	max-width: 100%;
 }
 .board_content p {
 	margin: 8px 0;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import axios from "axios";
 import "./App.css";
 import Header from "./components/Header";
 import Nav from "./components/Nav";
@@ -16,6 +17,7 @@ import UserPage from "./pages/UserPage";
 import UserEdit from "./pages/UserEdit";
 import BoardDetailEdit from "./pages/BoardDetailEdit";
 import Admin from "./pages/Admin";
+import Loading from "./components/Loading";
 
 export interface userDataType {
 	createdAt: string;
@@ -29,9 +31,28 @@ export interface userDataType {
 }
 
 function App() {
+	const api = process.env.REACT_APP_API_URL;
+	const [isLoading, setIsLoading] = useState(true);
 	const [isLogin, setIsLogin] = useState(false);
 	const [userData, setUserData] = useState<userDataType>();
 	const [isNavDrawerOn, setIsNavDrawerOn] = useState(false);
+	const [menuData, setMenuData] = useState<any[]>([]);
+	const fetchMenuData = () => {
+		axios
+			.get(`${api}/api/v1/board/menu`)
+			.then((response) => {
+				setMenuData(response.data.data);
+				setIsLoading(false);
+			})
+			.catch((error) => {
+				console.error("에러", error);
+				setIsLoading(true);
+			});
+	};
+	useEffect(() => {
+		fetchMenuData();
+	}, []);
+
 	return (
 		<div className="App">
 			<Router>
@@ -43,37 +64,44 @@ function App() {
 					setIsNavDrawerOn={setIsNavDrawerOn}
 				/>
 				<div className="page_wrap">
-					<Nav />
+					<Nav menuData={menuData} />
 					<main className="container">
-						<Routes>
-							<Route path="/" element={<Home />} />
-							<Route
-								path="/login"
-								element={<Login setIsLogin={setIsLogin} />}
-							/>
-							<Route path="/signup" element={<Signup />} />
-							<Route path="/validateEmail" element={<ValidateEmail />} />
-							<Route path="/newPassword" element={<NewPassword />} />
-							<Route path="/board/:boardInfo" element={<BoardList />} />
-							<Route
-								path="/board/:boardInfo/:postId"
-								element={<BoardDetail />}
-							/>
-							<Route path="/board/write" element={<BoardWrite />} />
-							<Route
-								path="/board/edit/:boardInfo/:postId"
-								element={<BoardDetailEdit />}
-							/>
-							<Route
-								path="/user/:userId"
-								element={<UserPage userData={userData} />}
-							/>
-							<Route
-								path="/user/:userId/edit"
-								element={<UserEdit userData={userData} />}
-							/>
-							<Route path="/admin" element={<Admin />} />
-						</Routes>
+						{isLoading ? (
+							<Loading />
+						) : (
+							<Routes>
+								<Route path="/" element={<Home />} />
+								<Route
+									path="/login"
+									element={<Login setIsLogin={setIsLogin} />}
+								/>
+								<Route path="/signup" element={<Signup />} />
+								<Route path="/validateEmail" element={<ValidateEmail />} />
+								<Route path="/newPassword" element={<NewPassword />} />
+								<Route
+									path="/board/:boardInfo"
+									element={<BoardList menuData={menuData} />}
+								/>
+								<Route
+									path="/:postId"
+									element={<BoardDetail menuData={menuData} />}
+								/>
+								<Route path="/board/write" element={<BoardWrite />} />
+								<Route
+									path="/board/edit/:postId"
+									element={<BoardDetailEdit />}
+								/>
+								<Route
+									path="/user/:userId"
+									element={<UserPage userData={userData} />}
+								/>
+								<Route
+									path="/user/:userId/edit"
+									element={<UserEdit userData={userData} />}
+								/>
+								<Route path="/admin" element={<Admin />} />
+							</Routes>
+						)}
 					</main>
 				</div>
 				<NavDrawer
@@ -82,6 +110,7 @@ function App() {
 					userData={userData}
 					setIsNavDrawerOn={setIsNavDrawerOn}
 					isNavDrawerOn={isNavDrawerOn}
+					menuData={menuData}
 				/>
 			</Router>
 		</div>

--- a/client/src/components/Boarditem.tsx
+++ b/client/src/components/Boarditem.tsx
@@ -33,12 +33,10 @@ interface BoardItemData {
 }
 
 const BoardItem = ({ data }: { data: BoardItemData }) => {
+	console.log(data.postId);
 	return (
 		<div className="board_item">
-			<a
-				href={`/board/${data.boardId}-${data.boardName}/${data.postId}`}
-				title={data.title}
-			>
+			<a href={`/${data.postId}`} title={data.title}>
 				<div className="board_item_element_wrap">
 					{data.boardId ? (
 						<p className="category_tag">{data.boardName}</p>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -46,7 +46,7 @@ const Header = (props: HeaderProps) => {
 	return (
 		<header className="header">
 			<h1>
-				<a href="./" className="logo" title="JBaccount 홈">
+				<a href="/" className="logo" title="JBaccount 홈">
 					JB account
 				</a>
 			</h1>

--- a/client/src/components/Loading.tsx
+++ b/client/src/components/Loading.tsx
@@ -1,0 +1,10 @@
+const Loading=()=>{
+ return(<div className="loading">
+ <div className="loading-dot"></div>
+ <div className="loading-dot"></div>
+ <div className="loading-dot"></div>
+ <div className="loading-dot"></div>
+</div>);
+}
+
+export default Loading;

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -3,7 +3,6 @@ import { ReactComponent as IconHome } from "./../assets/icon_home.svg";
 import iconArrowDown from "./../assets/icon_arrow_down.svg";
 import { MouseEvent, useEffect, useState, Dispatch } from "react";
 import { NavLink } from "react-router-dom";
-import axios from "axios";
 import NavInfo from "./NavInfo";
 
 const createMenuNode = (data: any[]) => {
@@ -11,7 +10,7 @@ const createMenuNode = (data: any[]) => {
 		<li key={idx} className="nav_menu_item">
 			{el.name ? (
 				<NavLink
-					to={`/board/${el.id}-${el.name}${el.isAdminOnly?"-adminOnly":""}`}
+					to={`/board/${el.name}`}
 					onClick={clickHandler}
 					className={({ isActive }) => (isActive ? "active" : "")}
 				>
@@ -36,19 +35,8 @@ const clickHandler = (event: React.MouseEvent<HTMLAnchorElement>): void => {
 	event.currentTarget.classList.toggle("unfold");
 };
 
-const Nav = () => {
+const Nav = ({ menuData }: { menuData: any[] }) => {
 	const api = process.env.REACT_APP_API_URL;
-	const [data, setData] = useState<any[]>([]);
-	useEffect(() => {
-		axios
-			.get(`${api}/api/v1/board/menu`)
-			.then((response) => {
-				setData(response.data.data);
-			})
-			.catch((error) => {
-				console.error("에러", error);
-			});
-	}, []);
 	return (
 		<nav className="nav">
 			<div className="home_link">
@@ -57,7 +45,7 @@ const Nav = () => {
 					HOME
 				</a>
 			</div>
-			<ul className="nav_menu depth1">{createMenuNode(data)}</ul>
+			<ul className="nav_menu depth1">{createMenuNode(menuData)}</ul>
 			<NavInfo />
 		</nav>
 	);

--- a/client/src/components/NavDrawer.tsx
+++ b/client/src/components/NavDrawer.tsx
@@ -1,8 +1,18 @@
 import Nav from "./Nav";
 import LoginInfo from "./LoginInfo";
 import iconClose from "./../assets/icon_close.svg";
+import { userDataType } from "./../App";
 
-const NavDrawer = (props: any) => {
+interface NavDrawerProps {
+	isLogin: boolean;
+	setIsLogin: React.Dispatch<React.SetStateAction<boolean>>;
+	userData: userDataType | undefined;
+	setIsNavDrawerOn: React.Dispatch<React.SetStateAction<boolean>>;
+	isNavDrawerOn: boolean;
+	menuData: any[];
+}
+
+const NavDrawer = (props: NavDrawerProps) => {
 	const handleClickNavDrawerClose = () => {
 		props.setIsNavDrawerOn(false);
 	};
@@ -22,10 +32,17 @@ const NavDrawer = (props: any) => {
 					>
 						<img src={iconClose} alt="네비게이션 드로어 닫기" />
 					</button>
-					<div className="drawer_title_wrap">
-						<h3 className="drawer_title">안녕하세요.</h3>
-						<p className="drawer_sub_title">로그인이 필요합니다.</p>
-					</div>
+					{props.isLogin ? (
+						<div className="drawer_title_wrap">
+							<h3 className="drawer_title">{props.userData?.nickname}</h3>
+							<p className="drawer_sub_title">{props.userData?.email}</p>
+						</div>
+					) : (
+						<div className="drawer_title_wrap">
+							<h3 className="drawer_title">안녕하세요.</h3>
+							<p className="drawer_sub_title">로그인이 필요합니다.</p>
+						</div>
+					)}
 					<LoginInfo
 						isDrawer={true}
 						isLogin={props.isLogin}
@@ -34,7 +51,7 @@ const NavDrawer = (props: any) => {
 					/>
 				</div>
 
-				<Nav />
+				<Nav menuData={props.menuData} />
 			</div>
 		</div>
 	);

--- a/client/src/pages/BoardDetail.tsx
+++ b/client/src/pages/BoardDetail.tsx
@@ -7,6 +7,7 @@ import BoardComment from "../components/BoardComment";
 interface BoardDetailData {
 	postId: number;
 	boardId: number;
+	boardName: string;
 	categoryId?: number;
 	memberId: number;
 	nickname: string;
@@ -18,11 +19,10 @@ interface BoardDetailData {
 	voteStatus: boolean;
 }
 
-const BoardDetail = () => {
+const BoardDetail = ({ menuData }: { menuData: any[] }) => {
 	const api = process.env.REACT_APP_API_URL;
 	const params = useParams();
 	const navigate = useNavigate();
-	const [boardId, boardName] = params.boardInfo!.split("-");
 	const [postData, setPostData] = useState<BoardDetailData>();
 	const [myMemberId, setmyMemberID] = useState<number>();
 	useEffect(() => {
@@ -62,7 +62,7 @@ const BoardDetail = () => {
 					headers: { Authorization: accessToken },
 				})
 				.then((res) => {
-					navigate(`/board/${boardId}-${boardName}`);
+					navigate(`/board/${postData!.boardName}`);
 				})
 				.catch((error) => {
 					alert("게시물 삭제를 실패했습니다.");
@@ -78,7 +78,7 @@ const BoardDetail = () => {
 				<>
 					<div className="board_header">
 						<div className="board_detail_info">
-							<p className="board_info">{params.boardInfo?.split("-")[1]}</p>
+							<p className="board_info">{postData!.boardName}</p>
 							{postData!.categoryId ? (
 								<p className="board_info">{postData!.categoryId}</p>
 							) : null}
@@ -93,16 +93,13 @@ const BoardDetail = () => {
 							<div className="info_item votes_info">
 								<input type="checkbox" id="board_vote" className="icon" />
 								<label htmlFor="board_vote" className="info">
-									12
+									{postData.voteCount}
 								</label>
 							</div>
 						</div>
 						{myMemberId === postData.memberId ? (
 							<div className="writer_action">
-								<a
-									href={`/board/edit/${boardId}-${boardName}/${params.postId}`}
-									className="link"
-								>
+								<a href={`/board/edit/${params.postId}`} className="link">
 									수정
 								</a>
 								<a href="" className="link" onClick={handleClickDeletePost}>


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [x]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
1. 메뉴 데이터를 받아오는 컴포넌트의 변경(Nav -> App으로)
기존에는 Nav컴포넌트에서 서버로 요청하여 전체 게시판 메뉴 데이터를 받아왔습니다. 
이를 최상위 컴포넌트인 App으로 옮겨 하위 컴포넌트인 Nav, BoardList, BoardDetail 등에서 해당 데이터를 props로 내려받을 수 있도록 했습니다.
2. 라우팅 변경
게시판 라우팅을 `/board/boardId-boardName`-> `board/boardName`으로 수정하고
게시글 라우팅을 `/board/boardId-boardName/postId` -> `/postId`로 수정하였습니다.
3. 로딩 인디케이터 추가
4. 스타일 등의 버그 등을 수정

# 느낀 점 및 어려운 점
1. 라우팅 변경에 따른 연쇄적인 문제점 해결
게시판의 기존 라우팅에 boardId가 들어간 이유는 이 파라미터의 boardId를 이용해 게시글을 서버로 요청하기 위해서였습니다.
그러나 라우팅에 boardName으로만 적용하게 되면서 어디서 boardId를 가져와야할까 고민해본 결과 Nav컴포넌트에서 요청하면 받아오는 전체 메뉴 데이터를 최상위인 App컴포넌트로 옮기기로 했습니다. 최상위 App컴포넌트로 데이터를 요청하여 받아오면 네비게이션인 Nav, 게시판 목록인 BoardList, 게시글인 BoardDetail에서 props로 그 데이터를 받아와서 사용할 수 있습니다. 서버로의 불필요한 요청도 줄이게 됩니다.
그러나 그러자 다른 문제가 생겼습니다.
2. 로딩 인디케이터 추가
데이터를 비동기적으로 받아오기 때문에 데이터를 받아오기 전에 컴포넌트를 렌더링하게 되면 에러가 뜹니다. 데이터에서 추출한 boardId로 데이터를 요청하여 렌더링하기 때문에 그 boardId가 undefined가 뜨면 api 요청을 할 수 없기 때문입니다. 그래서 데이터를 렌더링하기 전에 로딩 인디케이터를 띄웠다가 메뉴를 띄워야 했습니다. 그래서 로딩 인디케이터를 추가하였습니다.

# [option] 관련 알림사항
버그 및 이슈 리포트에 있는 내용을 우선적으로 해결하고 추후에 BoardWrite컴포넌트에서도 메뉴 데이터를 props로 받을 수 있도록 수정해야겠습니다.
