### PR TITLE
[fix/240804] 버그 수정 및 요구사항 반영

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -332,6 +332,20 @@ input.error {
 	height: 36px;
 	padding: 6px 0;
 	background-color: var(--primary-container-color);
+	position: relative;
+	overflow: hidden;
+}
+.login_info_icon_wrap.profile > img {
+	width: 100%;
+	aspect-ratio: 10 / 10;
+	position: absolute;
+	left: 0;
+	top: 0;
+}
+.login_info_icon_wrap.profile > .default {
+	width: 24px;
+	height: 24px;
+	position: static;
 }
 .login_info_wrap .login_info_btns_name {
 	display: none;
@@ -509,7 +523,11 @@ input.error {
 	margin-left: auto;
 	transform: rotate(180deg);
 }
-.nav a.unfold .toggle_updown {
+.nav a .toggle_updown > img {
+	width: 24px;
+	height: 24px;
+}
+.nav a .toggle_updown.unfold {
 	transform: rotate(0deg);
 }
 .depth2 {
@@ -528,7 +546,8 @@ input.error {
 	background: none;
 	color: var(--primary-color);
 }
-.depth2 .nav_menu_item a:hover::before {
+.depth2 .nav_menu_item a:hover::before,
+.depth2 .nav_menu_item a.active::before {
 	content: "";
 	position: absolute;
 	left: 16px;
@@ -538,7 +557,7 @@ input.error {
 	border-radius: 100%;
 	background: var(--primary-color);
 }
-.nav a.unfold + .nav_menu.depth2 {
+.nav_menu.depth2.unfold {
 	max-height: fit-content;
 	padding: 12px 0;
 }
@@ -1220,10 +1239,16 @@ input.error {
 .user_button_wrap {
 	margin-left: auto;
 }
-.user_button_wrap a {
+.user_button_wrap .user_button {
+	padding: 10px 24px;
+	font-size: var(--fs-normal);
+	font-weight: var(--fw-bold);
+	background: var(--white);
+	border-radius: var(--br-md);
+	border: 1px solid var(--primary-color);
 	color: var(--primary-color);
 }
-.user_button_wrap > button:first-child {
+.user_button_wrap > .user_button:first-child {
 	margin-right: 12px;
 }
 .user_written_wrap {
@@ -1507,7 +1532,7 @@ input.error {
 }
 
 /* ------------------------------- responsive: mobile ------------------------------- */
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 1023px) {
 	:root {
 		/* font size */
 		--fs-h1: 36px;
@@ -1723,11 +1748,17 @@ input.error {
 	.user_button_wrap {
 		margin: 0 auto;
 		padding-top: 24px;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
 	}
-	.user_button_wrap a {
+	.user_button_wrap .user_button {
 		display: block;
 		text-align: center;
 		margin-bottom: 8px;
+	}
+	.user_button_wrap .user_button:first-child {
+		margin-right: 0;
 	}
 	/* userEdit */
 	.user_edit_wrap {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,7 +64,7 @@ function App() {
 					setIsNavDrawerOn={setIsNavDrawerOn}
 				/>
 				<div className="page_wrap">
-					<Nav menuData={menuData} />
+					<Nav menuData={menuData} setIsNavDrawerOn={setIsNavDrawerOn} />
 					<main className="container">
 						{isLoading ? (
 							<Loading />

--- a/client/src/assets/tokenActions.ts
+++ b/client/src/assets/tokenActions.ts
@@ -15,7 +15,7 @@ export const saveAccessToken = (token: string) => {
 };
 export const removeAccessToken = () => {
 	if (document.cookie !== "") {
-		document.cookie = "cookiename= ; expires = Thu, 01 Jan 1970 00:00:00 GMT";
+		document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
 	}
 	localStorage.removeItem("accessToken");
 };

--- a/client/src/components/BoardComment.tsx
+++ b/client/src/components/BoardComment.tsx
@@ -4,6 +4,7 @@ import CommentListItem from "./CommentListItem";
 import axios from "axios";
 import { getAccessToken } from "../assets/tokenActions";
 import dummyCommentsData from "./../data/boardCommentsData.json";
+import Loading from "./Loading";
 
 const BoardComment = ({
 	postId,
@@ -15,17 +16,17 @@ const BoardComment = ({
 	const api = process.env.REACT_APP_API_URL;
 	const [comment, setComment] = useState<string>("");
 	const [commentList, setCommentList] = useState<any>();
+	const [isLoading, setIsLoading] = useState(true);
 
 	const fetchCommentData = () => {
 		const accessToken = getAccessToken();
 		if (accessToken) {
 			axios
-				.get(`${api}/api/v1/comment?postId=${postId}`, {
-					headers: { Authorization: accessToken },
-				})
+				.get(`${api}/api/v1/comment?postId=${postId}`)
 				.then((res) => {
 					// console.log(res.data.data); 성공적으로 삭제해도 isRemoved 떠서 확인필요
-					setCommentList(res.data.data);
+					setCommentList(res.data.data.comments);
+					setIsLoading(false);
 				})
 				.catch((_) => {});
 		}
@@ -85,52 +86,49 @@ const BoardComment = ({
 					onClick={handleClickCommentSubmit}
 				/>
 			</div>
-			{commentList ? (
+			{isLoading ? (
+				<Loading />
+			) : (
 				<div className="comments_list_wrap">
 					<h4 className="comments_title">댓글 목록</h4>
-					<ul className="comment_list">
-						{/* 기본  */}
-						{commentList?.map((el: any, idx: number) => {
-							return (
-								<li className="comment_list_item" key={idx}>
-									<CommentListItem
-										data={el}
-										isChild={false}
-										postId={postId}
-										memberId={memberId}
-										fetchData={fetchCommentData}
-									/>
-									{el.children.length > 0 ? (
-										<div className="comment_children_wrap">
-											<ul className="comment_children_list">
-												{el.children.map((child: any, childIdx: number) => (
-													<li className="comment_list_item">
-														<CommentListItem
-															data={child}
-															isChild={true}
-															postId={postId}
-															memberId={memberId}
-															fetchData={fetchCommentData}
-														/>
-													</li>
-												))}
-											</ul>
-										</div>
-									) : null}
-								</li>
-							);
-						})}
-
-						{/* 답글 있을 때: 접혔을 때  */}
-						{/* 답글 있을 때: 펼쳤을 때  */}
-						{/* 내가 쓴 글인 경우 */}
-						{/* 내가 쓴 글인 경우: 수정할 때  */}
-						{/* 대댓글 기본  */}
-						{/* 대댓글 기본: 내가 쓴 경우 */}
-						{/* 대댓글 기본: 내가 쓴 경우: 수정할 때 */}
-					</ul>
+					{commentList.length > 0 ? (
+						<ul className="comment_list">
+							{commentList?.map((el: any, idx: number) => {
+								return (
+									<li className="comment_list_item" key={idx}>
+										<CommentListItem
+											data={el}
+											isChild={false}
+											postId={postId}
+											memberId={memberId}
+											fetchData={fetchCommentData}
+										/>
+										{el.children.length > 0 ? (
+											<div className="comment_children_wrap">
+												<ul className="comment_children_list">
+													{el.children.map((child: any, childIdx: number) => (
+														<li className="comment_list_item">
+															<CommentListItem
+																data={child}
+																isChild={true}
+																postId={postId}
+																memberId={memberId}
+																fetchData={fetchCommentData}
+															/>
+														</li>
+													))}
+												</ul>
+											</div>
+										) : null}
+									</li>
+								);
+							})}
+						</ul>
+					) : (
+						"댓글이 없습니다."
+					)}
 				</div>
-			) : null}
+			)}
 		</div>
 	);
 };

--- a/client/src/components/Boarditem.tsx
+++ b/client/src/components/Boarditem.tsx
@@ -1,22 +1,5 @@
-//api문서 기준
-// interface Data {
-// 	postId: number;
-// 	boardId: number;
-// 	boardName: string;
-// 	categoryId?: number;
-// 	categoryName?: string;
-// 	memberId: number;
-// 	memberName: string;
-// 	title: string;
-// 	content: string;
-// 	commentsCount?: number;
-// 	createdAt: string;
-// 	timeInfo: string;
-// }
-
 import { useEffect } from "react";
 
-//서버 응답 기준
 interface BoardItemData {
 	postId?: number;
 	boardId: number;
@@ -33,7 +16,6 @@ interface BoardItemData {
 }
 
 const BoardItem = ({ data }: { data: BoardItemData }) => {
-	console.log(data.postId);
 	return (
 		<div className="board_item">
 			<a href={`/${data.postId}`} title={data.title}>
@@ -50,10 +32,6 @@ const BoardItem = ({ data }: { data: BoardItemData }) => {
 								<span className="info">{data.commentsCount}</span>
 							</p>
 						) : null}
-						{/* <p className="info_item votes_info">
-						<span className="icon">득표수</span>
-						<span className="info">{data.voteCount}</span>
-					</p> */}
 					</div>
 				</div>
 				<h3 className="title">{data.title}</h3>

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -6,6 +6,8 @@ export interface ButtonProps {
 	buttonSize: "big" | "small";
 	buttonLabel: string;
 	onClick?: () => void;
+	onKeyPress?: (event: React.KeyboardEvent<HTMLElement>) => void;
+	type?: "button" | "submit" | "reset";
 }
 
 const Button = ({

--- a/client/src/components/LoginInfo.tsx
+++ b/client/src/components/LoginInfo.tsx
@@ -30,11 +30,15 @@ const LoginInfo = (props: LoginInfoProps) => {
 						className="login_info_btns link_profile"
 						title="클릭시 내 프로필로 이동합니다."
 					>
-						<div className="login_info_icon_wrap">
+						<div className="login_info_icon_wrap profile">
 							{props.userData?.profileImage ? (
 								<img src={props.userData?.profileImage} />
 							) : (
-								<img src={iconUser} alt="기본 유저 아이콘" />
+								<img
+									src={iconUser}
+									alt="기본 유저 아이콘"
+									className="default"
+								/>
 							)}
 						</div>
 						{props.isDrawer ? (

--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -5,38 +5,57 @@ import { MouseEvent, useEffect, useState, Dispatch } from "react";
 import { NavLink } from "react-router-dom";
 import NavInfo from "./NavInfo";
 
-const createMenuNode = (data: any[]) => {
-	return data!.map((el: any, idx: number) => (
-		<li key={idx} className="nav_menu_item">
-			{el.name ? (
-				<NavLink
-					to={`/board/${el.name}`}
-					onClick={clickHandler}
-					className={({ isActive }) => (isActive ? "active" : "")}
-				>
-					{el.name}
-					{el.category && el.category.length !== 0 ? (
-						<i className="toggle_updown">
-							<img src={iconArrowDown} alt="메뉴 펼치기 접기 토글 아이콘" />
-						</i>
-					) : null}
-				</NavLink>
-			) : (
-				<a href="">{el.categoryName}</a>
-			)}
-			{el.category && el.category.length !== 0 ? (
-				<ul className="nav_menu depth2">{createMenuNode(el.category)}</ul>
-			) : null}
-		</li>
-	));
-};
-
-const clickHandler = (event: React.MouseEvent<HTMLAnchorElement>): void => {
-	event.currentTarget.classList.toggle("unfold");
-};
-
-const Nav = ({ menuData }: { menuData: any[] }) => {
+const Nav = ({
+	menuData,
+	setIsNavDrawerOn,
+}: {
+	menuData: any[];
+	setIsNavDrawerOn: React.Dispatch<React.SetStateAction<boolean>> | undefined;
+}) => {
 	const api = process.env.REACT_APP_API_URL;
+	const [unfold, setUnfold] = useState(false);
+	const createMenuNode = (data: any[]) => {
+		return data!.map((el: any, idx: number) => (
+			<li key={idx} className="nav_menu_item">
+				{el.name ? (
+					<NavLink
+						to={`/board/${el.name}`}
+						onClick={clickMenuHandler}
+						className={({ isActive }) => (isActive ? "active" : "")}
+					>
+						{el.name}
+						{el.category && el.category.length !== 0 ? (
+							<button className="toggle_updown" onClick={clickToggleHandler}>
+								<img src={iconArrowDown} alt="메뉴 펼치기 접기 토글 아이콘" />
+							</button>
+						) : null}
+					</NavLink>
+				) : (
+					<a href="">{el.categoryName}</a>
+				)}
+				{el.category && el.category.length !== 0 ? (
+					<ul className={unfold ? "nav_menu depth2 unfold" : "nav_menu depth2"}>
+						{createMenuNode(el.category)}
+					</ul>
+				) : null}
+			</li>
+		));
+	};
+
+	const clickMenuHandler = (
+		event: React.MouseEvent<HTMLAnchorElement>
+	): void => {
+		if (setIsNavDrawerOn !== undefined) setIsNavDrawerOn(false);
+	};
+	const clickToggleHandler = (
+		event: React.MouseEvent<HTMLButtonElement>
+	): void => {
+		event.currentTarget.classList.toggle("unfold");
+		event.preventDefault();
+		event.stopPropagation();
+		setUnfold((prev) => !prev);
+	};
+
 	return (
 		<nav className="nav">
 			<div className="home_link">

--- a/client/src/components/NavDrawer.tsx
+++ b/client/src/components/NavDrawer.tsx
@@ -51,7 +51,10 @@ const NavDrawer = (props: NavDrawerProps) => {
 					/>
 				</div>
 
-				<Nav menuData={props.menuData} />
+				<Nav
+					menuData={props.menuData}
+					setIsNavDrawerOn={props.setIsNavDrawerOn}
+				/>
 			</div>
 		</div>
 	);

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -46,7 +46,8 @@ const Login = (props: Props) => {
 		isRequired: true,
 		valueType: "password",
 	};
-	const handleSubmit = () => {
+	const handleSubmit = (event?: React.FormEvent) => {
+		if (event && "preventDefault" in event) event.preventDefault();
 		setIsError((prevState) => ({
 			...prevState,
 			email: !validator(validatorStatusEmail),
@@ -65,35 +66,48 @@ const Login = (props: Props) => {
 				alert("로그인에 실패했습니다."); //수정 필요
 			});
 	};
+	const handleKeyPress = (event: React.KeyboardEvent<HTMLElement>) => {
+		if (event.key === "Enter") {
+			event.preventDefault();
+			handleSubmit();
+		}
+	};
 
 	return (
 		<div className="input_box login_box">
 			<h3 className="title_h3">로그인</h3>
 			<div className="content">
-				<Input
-					InputLabel="이메일"
-					isLabel={true}
-					errorMsg="올바른 이메일을 입력해 주세요."
-					inputAttr={{ type: "text", placeholder: "이메일을 입력하세요" }}
-					setInputValue={setEmailValue}
-					inputValue={form.email}
-					isError={isError.email}
-				/>
-				<Input
-					InputLabel="비밀번호"
-					isLabel={true}
-					errorMsg="올바른 비밀번호를 입력해 주세요."
-					inputAttr={{ type: "password", placeholder: "비밀번호를 입력하세요" }}
-					setInputValue={setPasswordValue}
-					inputValue={form.password}
-					isError={isError.password}
-				/>
-				<Button
-					buttonType="primary"
-					buttonSize="big"
-					buttonLabel="로그인"
-					onClick={handleSubmit}
-				/>
+				<form onSubmit={handleSubmit} onKeyDown={handleKeyPress}>
+					<Input
+						InputLabel="이메일"
+						isLabel={true}
+						errorMsg="올바른 이메일을 입력해 주세요."
+						inputAttr={{ type: "text", placeholder: "이메일을 입력하세요" }}
+						setInputValue={setEmailValue}
+						inputValue={form.email}
+						isError={isError.email}
+					/>
+					<Input
+						InputLabel="비밀번호"
+						isLabel={true}
+						errorMsg="올바른 비밀번호를 입력해 주세요."
+						inputAttr={{
+							type: "password",
+							placeholder: "비밀번호를 입력하세요",
+						}}
+						setInputValue={setPasswordValue}
+						inputValue={form.password}
+						isError={isError.password}
+					/>
+					<Button
+						buttonType="primary"
+						buttonSize="big"
+						buttonLabel="로그인"
+						type="submit"
+						onClick={handleSubmit}
+						onKeyPress={handleKeyPress}
+					/>
+				</form>
 				<div className="sns_login_wrap">
 					<h4 className="sns_login_title">소셜 로그인</h4>
 					<p className="sns_login_description">

--- a/client/src/pages/UserPage.tsx
+++ b/client/src/pages/UserPage.tsx
@@ -54,9 +54,13 @@ const UserPage: React.FC<userPageProps> = ({ userData }) => {
 					<p className="email">{userData?.email}</p>
 				</div>
 				<div className="user_button_wrap">
-					<a href={`/user/${userData?.id}/edit`}>사용자 정보 수정</a>
+					<a href={`/user/${userData?.id}/edit`} className="user_button">
+						사용자 정보 수정
+					</a>
 					{userData?.role === "ADMIN" ? (
-						<a href={`/admin`}>관리자 페이지</a>
+						<a href={`/admin`} className="user_button">
+							관리자 페이지
+						</a>
 					) : null}
 				</div>
 			</div>


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [ ]  Feature
- [x]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- [버그 이슈 리포트 17] 구글 로그아웃시 쿠키 삭제 문제 수정
- [버그 이슈 리포트 21, 37] 댓글 목록 관련 에러 수정(미로그인시 노출 등)
- [버그 이슈 리포트 28] 로그인시 엔터키로도 로그인 가능
- [버그 이슈 리포트 36] 모바일 네비게이션 드로어 메뉴 클릭시 닫힘, 토클 버튼 클릭시에는 닫히지 않도록 변경
- [버그 이슈 리포트 38] 사용자 페이지 상단의 프로필 변경, 관리자 페이지 등의 버튼 모양 디자인 반영

# 느낀 점 및 어려운 점
양도 양이지만 로그인시 엔터키 로그인, 모바일 네비게이션 드로어 메뉴 관련이 좀 시간이 걸렸습니다.
## 1. 로그인시 엔터키로도 로그인
- 로그인할 때 엔터키로도 로그인이 되려면 기존 로그인 영역을 감싸는 form 태그에 onKeyPress 라는 이벤트를 추가해야 합니다.
그리고 해당 이벤트에서 키가 엔터키인 경우를 판별해 로그인 처리를 하는데, 새로고침이 발생하지 않도록 해당 이벤트와 기존 submit 이벤트 "모두"에 `event.preventDefault()`를 추가해주어야 했습니다.
- 작업자체는 어려운게 아니나 타입스크립트를 사용해서 애를 먹었습니다...(진짜 타입스크립트 저는 그렇게 간절하지 않습니다...) React.formEvent와 React.KeyboardEvent 타입은 읽어보면 어려운 타입이 아니지만 이걸 알기 전에는 다소 어려웠습니다. 뭐든 알고나면 쉬워보여도 하기 전에 막막한 것들이 있습니다. 인류가 괜히 농사짓기까지 수천년이 걸린게 아닙니다...흙흙
- 그리고 handleSubmit함수에서는 이벤트가 없을 경우(유효성 검사에 통과못한 경우 등)를 대비해 
```js
if (event && "preventDefault" in event) event.preventDefault();
```
처럼 event가 발생했을 경우에만 새로고침을 막아줘야 에러가 생기지 않습니다.
## 2. 네비게이션 드로어 요구사항 반영
요구사항은 '메뉴만 클릭하면 그 메뉴로 이동하면서 드로어가 닫히고, 하위 메뉴 화살표 토글 버튼을 클릭하면 드로어가 닫히지 말아라'였습니다. 이를 해결하기 위해선 이벤트 버블링, 캡쳐링도 알아야 하지만 기존에 적용된 하위 메뉴 노출 토클 기능을 분리해야 했습니다.
- 기존에는 화살표 토글 버튼위 부모 요소인 메뉴 링크 버튼을 클릭했을 때도 토글 기능이 작동하도록 했는데, 이 때 메뉴 링크에 스타일이 추가됩니다. 그리고 CSS의 `+`연산자를 사용해 바로 옆의 하위 메뉴가 노출되도록 되어있습니다.
이를 메뉴 링크의 자식 요소인 화살표 버튼을 클릭했을 때만 토글 기능이 작동하도록 걷어냈고, CSS로는 하위메뉴에 별도의 클래스를 부여하고 리액트의 상태를 사용해 상태에 따라 클래스명이 바뀌도록 변경하였습니다.
- 위의 요구사항을 반영하기 위해서는 이벤트 버블링, 캡쳐링을 잘 이해해야 해서 다시 공부했습니다. 그리고 아래와 같이 경우의 수를 잘 파악하여 알맞은 처리를 해주어야 했습니다.
-> 하위 화살표를 클릭했을 때 일단 메뉴 이동을 막으려면: `event.preventDefault`를 사용해 이벤트를 막아야 합니다.
-> 하위 화살표가 아닌 링크 버튼을 클릭했을 때: 이 때만 네비게이션 드로어가 사라지도록 `setIsNavDrawerOn(false);`를 입력합니다.
-> 하위 화살표를 클릭했을 때만 하위 메뉴 노출 토글 기능이 작동되려면: `event.stopPropagation()`를 사용해 부모 요소인 링크에는 해당 효과가 일어나지 않도록 합니다.

# [option] 관련 알림사항
이제 대략적인 에러는 거의 다 해결했으므로 회원가입시 이메일 인증을 복구하려고 합니다.
