### PR TITLE
[feat/vote] 투표 기능 추가

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -824,8 +824,22 @@ input.error {
 .info_item.comments_info .icon {
 	background-image: url("./assets/icon_sms.svg");
 }
+.info_item.votes_info {
+	margin-left: auto;
+	height: 20px;
+	padding: 0 8px;
+	border-radius: 20px;
+	border: 1px solid var(--border-color);
+	background-color: var(--white);
+}
 .info_item.votes_info .icon {
 	background-image: url("./assets/icon_thumb_up.svg");
+}
+.info_item.votes_info.voted {
+	background-color: var(--on-background-color);
+}
+.info_item.votes_info.voted .info {
+	color: var(--white);
 }
 /* board editor */
 .board_editor_button_wrap {
@@ -929,7 +943,7 @@ input.error {
 	overflow: hidden;
 	margin-right: 4px;
 }
-.board_detail_info .info_item {
+/* .board_detail_info .info_item {
 	position: relative;
 }
 .board_detail_info .info_item .info {
@@ -951,7 +965,7 @@ input.error {
 .board_detail_info .info_item .icon:checked + label {
 	background: var(--on-background-color);
 	color: var(--white);
-}
+} */
 .board_detail_box .writer_action {
 	text-align: right;
 }
@@ -1084,7 +1098,7 @@ input.error {
 .comment_user_profile .comment_ceated_time {
 	color: var(--on-background-secondary-color);
 }
-.comment_likes {
+/* .comment_likes {
 	margin-left: auto;
 	height: 20px;
 	padding: 0 8px 0 26px;
@@ -1092,7 +1106,7 @@ input.error {
 	border: 1px solid var(--border-color);
 	background: url("./assets/icon_thumb_up.svg") no-repeat;
 	background-position: 8px center;
-}
+} */
 .comment_content {
 	margin-bottom: 12px;
 }

--- a/client/src/components/CommentItem.tsx
+++ b/client/src/components/CommentItem.tsx
@@ -1,4 +1,4 @@
-import { string } from "prop-types";
+import VoteInfo from "./VoteInfo";
 
 interface CommentItemData {
 	postId: number;
@@ -24,11 +24,14 @@ const CommentItem = ({ data }: { data: any }) => {
 						<span className="icon">득표수</span>
 						<span className="info">{data.voteCount}</span>
 					</p>
+					<VoteInfo
+						voteCount={data.voteCount}
+						isVoted={false}
+						endpoint={`/api/v1/vote/comment/${data.commentId}`}
+					/>
 				</div>
 			</div>
-			<p className="comment">
-				{data.text}
-			</p>
+			<p className="comment">{data.text}</p>
 			<div className="board_item_element_wrap">
 				<p className="board_date">{data.createdAt}</p>
 			</div>

--- a/client/src/components/VoteInfo.tsx
+++ b/client/src/components/VoteInfo.tsx
@@ -1,0 +1,48 @@
+import axios from "axios";
+import { getAccessToken } from "../assets/tokenActions";
+import { useState } from "react";
+
+const VoteInfo = ({
+	voteCount,
+	isVoted,
+	endpoint,
+}: {
+	voteCount: number | string;
+	isVoted: boolean;
+	endpoint: string;
+}) => {
+	const api = process.env.REACT_APP_API_URL;
+	const [vetes, setVotes] = useState(voteCount);
+	const [hasVoted, setHasVoted] = useState(isVoted);
+
+	const handleClickVote = () => {
+		const accessToken = getAccessToken();
+		axios
+			.post(
+				`${api}${endpoint}`,
+				{},
+				{
+					headers: { Authorization: accessToken },
+				}
+			)
+			.then((_) => {
+				alert("투표 성공");
+				setVotes((prev) => Number(prev) + 1);
+				setHasVoted(true);
+			})
+			.catch((_) => {
+				alert("투표에 실패했습니다.");
+			});
+	};
+
+	return (
+		<button
+			className={`info_item votes_info${hasVoted ? " voted" : ""}`}
+			onClick={handleClickVote}
+		>
+			<span className="icon">득표수</span>
+			<span className="info">{vetes}</span>
+		</button>
+	);
+};
+export default VoteInfo;

--- a/client/src/pages/BoardDetail.tsx
+++ b/client/src/pages/BoardDetail.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
 import { getAccessToken } from "../assets/tokenActions";
 import BoardComment from "../components/BoardComment";
+import VoteInfo from "../components/VoteInfo";
 
 interface BoardDetailData {
 	postId: number;
@@ -90,12 +91,11 @@ const BoardDetail = ({ menuData }: { menuData: any[] }) => {
 								<div className="profile_img_wrap"></div>
 								<p className="board_writer">{postData.nickname}</p>
 							</div>
-							<div className="info_item votes_info">
-								<input type="checkbox" id="board_vote" className="icon" />
-								<label htmlFor="board_vote" className="info">
-									{postData.voteCount}
-								</label>
-							</div>
+							<VoteInfo
+								voteCount={postData.voteCount}
+								isVoted={postData.voteStatus}
+								endpoint={`/api/v1/vote/post/${postData.postId}`}
+							/>
 						</div>
 						{myMemberId === postData.memberId ? (
 							<div className="writer_action">


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [x]  Feature
- [ ]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 투표 기능 추가로 투표 버튼 공통 컴포넌트 voteInfo 추가
- 게시글, 댓글 영역 투표 부분 voteInfo 컴포넌트로 대체

# 느낀 점 및 어려운 점
딱히 어려운 점은 없었습니다.
다만 다음 번에 활용을 위해 투표 및 좋아요 기능을 만들 때 필요한 내용들을 정리해봅니다.

```
UI는 굳이 input type check가 아니고 button이어도 괜찮은 듯하다.
1. 초기 상태 설정: 좋아요 수, 사용자의 좋아요 여부 등
2. 상태 관리: 초기값을 서버로부터 받아와 설정
3. handleClick 함수
중복 클릭 방지: 사용자가 이미 좋아요를 눌렀는지 확인하여 요청을 보내지 않도록 조치
서버 요청: 서버로 POST 요청.
요청이 성공하면 좋아요 수를 증가시키고, 좋아요 여부를 true로 설정
4. UI 업데이트
좋아요 여부에 따라 UI를 업데이트
```

# [option] 관련 알림사항
만들고보니 
- 이미 투표한 게시글이나 댓글일 경우 서버에서 어떻게 알려주는지 더 알아볼 필요가 있는 것 같습니다.
- 위 문제가 해결되면 한 번 클릭한 경우 두 번 클릭을 방지하는 코드를 작업해야 할 것 같스빈다. 
